### PR TITLE
feat(a2a): Add push notification handling to A2A mock server

### DIFF
--- a/ai-mocks-a2a/README.md
+++ b/ai-mocks-a2a/README.md
@@ -1,0 +1,7 @@
+# AI Mocks A2A
+
+A mock server for testing Agent-to-Agent (A2A) protocol integrations.
+
+## Overview
+
+This library provides a mock server that simulates an A2A protocol endpoint for testing purposes. It allows developers to test their A2A client implementations without connecting to a real A2A server.

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -22,11 +22,13 @@ import me.kpavlov.mokksy.ServerConfiguration
 
 private const val DEFAULT_NOTIFICATIONS_URI = "/notifications"
 
-public open class MockAgentServer @JvmOverloads constructor(
-    port: Int = 0,
+@Suppress("TooManyFunctions")
+public open class MockAgentServer private constructor(
+    port: Int,
     verbose: Boolean = false,
-    public val notificationsUri: String = DEFAULT_NOTIFICATIONS_URI,
-    private val notificationListener: NotificationListener = NotificationListener(notificationsUri),
+    public val notificationsUri: String,
+    private val notificationListener: NotificationListener,
+    private val notificationSender: NotificationSender
 ) : AbstractMockLlm(
     port = port,
     configuration =
@@ -38,18 +40,40 @@ public open class MockAgentServer @JvmOverloads constructor(
             )
         },
     applicationConfigurer = {
-        this.configureNotificationListener(
+        configureNotificationListener(
             notificationsUri = notificationsUri,
-            listener = notificationListener
+            listener = notificationListener ,
+            verbose = verbose,
         )
     }
 ) {
+    /**
+     * Constructor for initializing a `MockAgentServer` instance.
+     *
+     * @param port The port on which the mock server will run.
+     *          Defaults to 0, which allows automatic port selection.
+     * @param verbose Determines whether the server operates in verbose mode for detailed logging.
+     *          Defaults to `false`.
+     * @param notificationsUri The URI used for receiving notifications.
+     *          Defaults to `DEFAULT_NOTIFICATIONS_URI`.
+     */
+    @JvmOverloads
+    public constructor(
+        port: Int = 0,
+        verbose: Boolean = false,
+        notificationsUri: String = DEFAULT_NOTIFICATIONS_URI,
+    ) : this(
+        port = port,
+        verbose = verbose,
+        notificationsUri = notificationsUri,
+        notificationListener = NotificationListener(notificationsUri),
+        notificationSender = NotificationSender()
+    )
+
 
     public fun notificationUrl(): String {
         return baseUrl() + notificationsUri
     }
-
-    private val notificationSender: NotificationSender = NotificationSender()
 
     /**
      * Configures a behavior for handling

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -5,28 +5,52 @@ import kotlinx.serialization.json.Json
 import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
 import me.kpavlov.aimocks.a2a.model.SendTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
+import me.kpavlov.aimocks.a2a.model.TaskId
 import me.kpavlov.aimocks.a2a.model.TaskResubscriptionRequest
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import me.kpavlov.aimocks.a2a.notifications.NotificationListener
+import me.kpavlov.aimocks.a2a.notifications.NotificationSender
+import me.kpavlov.aimocks.a2a.notifications.TaskNotificationHistory
+import me.kpavlov.aimocks.a2a.notifications.configureNotificationListener
 import me.kpavlov.aimocks.core.AbstractBuildingStep
 import me.kpavlov.aimocks.core.AbstractMockLlm
 import me.kpavlov.mokksy.ServerConfiguration
 
+private const val DEFAULT_NOTIFICATIONS_URI = "/notifications"
+
 public open class MockAgentServer @JvmOverloads constructor(
     port: Int = 0,
     verbose: Boolean = false,
+    public val notificationsUri: String = DEFAULT_NOTIFICATIONS_URI,
+    private val notificationListener: NotificationListener = NotificationListener(notificationsUri),
 ) : AbstractMockLlm(
-        port = port,
-        configuration =
-            ServerConfiguration(
-                verbose = verbose,
-            ) { config ->
-                config.json(
-                    Json { ignoreUnknownKeys = true },
-                )
-            },
-    ) {
+    port = port,
+    configuration =
+        ServerConfiguration(
+            verbose = verbose,
+        ) { config ->
+            config.json(
+                Json { ignoreUnknownKeys = true },
+            )
+        },
+    applicationConfigurer = {
+        this.configureNotificationListener(
+            notificationsUri = notificationsUri,
+            listener = notificationListener
+        )
+    }
+) {
+
+    public fun notificationUrl(): String {
+        return baseUrl() + notificationsUri
+    }
+
+    private val notificationSender: NotificationSender = NotificationSender()
+
     /**
      * Configures a behavior for handling
      * ["Agent Card"](https://google.github.io/A2A/#/documentation?id=agent-card) mock server requests.
@@ -301,7 +325,8 @@ public open class MockAgentServer @JvmOverloads constructor(
      * ```
      *
      * @param name An optional identifier for the configured request.
-     * @return An instance of `TaskResubscriptionBuildingStep` to define the response behavior for task resubscription requests.
+     * @return An instance of `TaskResubscriptionBuildingStep` to define the response behavior
+     * for task resubscription requests.
      */
     @JvmOverloads
     public fun taskResubscription(name: String? = null): TaskResubscriptionBuildingStep {
@@ -318,5 +343,17 @@ public open class MockAgentServer @JvmOverloads constructor(
             buildingStep = requestStep,
             mokksy = mokksy,
         )
+    }
+
+    public fun getTaskNotifications(taskId: TaskId): TaskNotificationHistory {
+        return notificationListener.getByTaskId(taskId)
+    }
+
+    @JvmOverloads
+    public suspend fun sendPushNotification(
+        config: PushNotificationConfig = PushNotificationConfig(url = notificationUrl()),
+        event: TaskUpdateEvent
+    ) {
+        notificationSender.sendPushNotification(config, event)
     }
 }

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/NotificationListener.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/NotificationListener.kt
@@ -1,0 +1,46 @@
+package me.kpavlov.aimocks.a2a.notifications
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.log
+import io.ktor.server.request.receive
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import java.util.concurrent.ConcurrentHashMap
+
+public class NotificationListener(internal val notificationsUri: String) {
+
+    private val taskNotificationsMap = ConcurrentHashMap<TaskId, TaskNotificationHistory>()
+
+    internal fun add(event: TaskUpdateEvent) {
+        getByTaskId(taskId = event.id()).add(event)
+    }
+
+    internal fun getByTaskId(taskId: TaskId): TaskNotificationHistory =
+        taskNotificationsMap.computeIfAbsent(taskId) {
+            TaskNotificationHistory(taskId = taskId)
+        }
+
+    internal fun clear(taskId: TaskId) {
+        taskNotificationsMap[taskId]?.clear()
+    }
+}
+
+internal fun Application.configureNotificationListener(
+    notificationsUri: String,
+    listener: NotificationListener
+) {
+    require(notificationsUri.isNotBlank()) { "notificationsUri must not be blank" }
+    require(notificationsUri.startsWith("/")) { "notificationsUri must start with '/'" }
+    require(notificationsUri.length > 1) { "notificationsUri must not be root url" }
+
+    routing {
+        post(listener.notificationsUri) {
+            val event = call.receive<TaskUpdateEvent>()
+            log.debug("Received task notification: {}", event)
+            listener.add(event)
+        }
+    }
+
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/NotificationListener.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/NotificationListener.kt
@@ -9,7 +9,7 @@ import me.kpavlov.aimocks.a2a.model.TaskId
 import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
 import java.util.concurrent.ConcurrentHashMap
 
-public class NotificationListener(internal val notificationsUri: String) {
+internal class NotificationListener(internal val notificationsUri: String) {
 
     private val taskNotificationsMap = ConcurrentHashMap<TaskId, TaskNotificationHistory>()
 
@@ -21,15 +21,12 @@ public class NotificationListener(internal val notificationsUri: String) {
         taskNotificationsMap.computeIfAbsent(taskId) {
             TaskNotificationHistory(taskId = taskId)
         }
-
-    internal fun clear(taskId: TaskId) {
-        taskNotificationsMap[taskId]?.clear()
-    }
 }
 
 internal fun Application.configureNotificationListener(
     notificationsUri: String,
-    listener: NotificationListener
+    listener: NotificationListener,
+    verbose: Boolean
 ) {
     require(notificationsUri.isNotBlank()) { "notificationsUri must not be blank" }
     require(notificationsUri.startsWith("/")) { "notificationsUri must start with '/'" }
@@ -38,7 +35,11 @@ internal fun Application.configureNotificationListener(
     routing {
         post(listener.notificationsUri) {
             val event = call.receive<TaskUpdateEvent>()
-            log.debug("Received task notification: {}", event)
+            if (verbose) {
+                log.info("Received task notification: {}", event)
+            } else {
+                log.trace("Received task notification: {}", event)
+            }
             listener.add(event)
         }
     }

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/NotificationSender.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/NotificationSender.kt
@@ -1,0 +1,40 @@
+package me.kpavlov.aimocks.a2a.notifications
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+
+internal class NotificationSender {
+
+    private val notificationClient: HttpClient = HttpClient() {
+        val json =
+            Json {
+                prettyPrint = true
+                isLenient = true
+            }
+        install(ContentNegotiation) {
+            json(json)
+        }
+    }
+
+    internal suspend fun sendPushNotification(
+        config: PushNotificationConfig,
+        taskUpdateEvent: TaskUpdateEvent
+    ) {
+        notificationClient.post(config.url) {
+            if (config.token != null) {
+                header("Authorization", "Bearer ${config.token}")
+            }
+            contentType(ContentType.Application.Json)
+            setBody(taskUpdateEvent)
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/TaskNotificationHistory.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/TaskNotificationHistory.kt
@@ -1,0 +1,39 @@
+package me.kpavlov.aimocks.a2a.notifications
+
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import java.util.concurrent.ConcurrentLinkedDeque
+
+public class TaskNotificationHistory(
+    public val taskId: TaskId,
+ ) {
+    private val events: ConcurrentLinkedDeque<TaskUpdateEvent> = ConcurrentLinkedDeque< TaskUpdateEvent>()
+
+
+    internal fun add(event: TaskUpdateEvent) {
+        events.offer(event)
+    }
+
+    internal fun clear() {
+        events.clear()
+    }
+
+    public fun events(): List<TaskUpdateEvent> = events.toList()
+
+    internal fun isEmpty(): Boolean = events.isEmpty()
+
+    internal fun isNotEmpty(): Boolean = !isEmpty()
+
+    internal fun find(predicate: (TaskUpdateEvent) -> Boolean): TaskUpdateEvent? = events.find(predicate)
+
+    internal fun extract(predicate: (TaskUpdateEvent) -> Boolean): List<TaskUpdateEvent>  {
+        events.filter(predicate).also { found ->
+            for (event in found) {
+                events.remove(event)
+            }
+            return found.toList()
+        }
+    }
+
+
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/ReceiveNotificationsTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/ReceiveNotificationsTest.kt
@@ -1,0 +1,38 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.taskArtifactUpdateEvent
+import kotlin.test.Test
+
+internal class ReceiveNotificationsTest : AbstractTest() {
+
+    @Test
+    fun `Should resubscribe to task`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+
+            val notificationHistory = a2aServer.getTaskNotifications(taskId)
+
+            notificationHistory.events() shouldHaveSize 0
+
+            val taskUpdateEvent = taskArtifactUpdateEvent {
+                id = taskId
+                artifact {
+                    name = "joke"
+                    parts +=
+                        textPart {
+                            text = "This is a notification joke!"
+                        }
+                    lastChunk = true
+                }
+            }
+            a2aServer.sendPushNotification(event=taskUpdateEvent)
+
+            notificationHistory.events() shouldContain taskUpdateEvent
+
+        }
+
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/notifications/TaskNotificationHistoryTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/notifications/TaskNotificationHistoryTest.kt
@@ -1,0 +1,126 @@
+package me.kpavlov.aimocks.a2a.notifications
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the TaskNotificationHistory class.
+ *
+ * The class manages a history of task update events for a specific task ID,
+ * providing methods for adding, retrieving, searching, and clearing those events.
+ */
+internal class TaskNotificationHistoryTest {
+
+    private lateinit var history: TaskNotificationHistory
+    private lateinit var taskId: TaskId
+    private lateinit var event : TaskUpdateEvent
+    private lateinit var event1 : TaskUpdateEvent
+    private lateinit var event2 :TaskUpdateEvent
+
+    @BeforeTest
+    fun beforeEach() {
+        taskId = UUID.randomUUID().toString()
+        history = TaskNotificationHistory(taskId)
+        event = mockk<TaskUpdateEvent>()
+        event1 = mockk<TaskUpdateEvent>()
+        event2 = mockk<TaskUpdateEvent>()
+    }
+
+    @Test
+    fun `add should store a new event in the event history`() {
+        history.add(event)
+
+        history.events() shouldContainExactly listOf(event)
+    }
+
+    @Test
+    fun `clear should remove all stored events`() {
+        history.add(event1)
+        history.add(event2)
+        history.clear()
+
+        history.isEmpty() shouldBe true
+        history.events() shouldHaveSize 0
+    }
+
+    @Test
+    fun `events should return all added events in insertion order`() {
+
+        history.add(event1)
+        history.add(event2)
+
+        history.events() shouldContainExactly listOf(event1, event2)
+    }
+
+    @Test
+    fun `isEmpty should return true if the event history is empty`() {
+        assertTrue(history.isEmpty())
+    }
+
+    @Test
+    fun `isEmpty should return false if the event history is not empty`() {
+        history.add(event)
+
+        assertFalse(history.isEmpty())
+    }
+
+    @Test
+    fun `isNotEmpty should return true if the event history is not empty`() {
+        history.add(event)
+
+        history.isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `find should return the first matching event`() {
+
+        history.add(event1)
+        history.add(event2)
+
+        val result = history.find { it == event1 }
+
+        result shouldBe event1
+    }
+
+    @Test
+    fun `find should return null if no event matches the predicate`() {
+
+        history.add(event)
+
+        val result = history.find { it.toString() == "nonexistent" }
+
+       result shouldBe null
+    }
+
+    @Test
+    fun `extract should remove and return all events matching the predicate`() {
+
+        history.add(event1)
+        history.add(event2)
+
+        val extracted = history.extract { it == event1 }
+
+        extracted shouldContainExactly listOf(event1)
+        history.events() shouldContainExactly listOf(event2)
+    }
+
+    @Test
+    fun `extract should return an empty list if no events match the predicate`() {
+
+        history.add(event)
+
+        val extracted = history.extract { it.toString() == "nonexistent" }
+
+        extracted shouldHaveSize 0
+        history.events() shouldContainExactly listOf(event)
+    }
+}

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
@@ -1,5 +1,6 @@
 package me.kpavlov.aimocks.core
 
+import io.ktor.server.application.Application
 import io.ktor.server.application.log
 import me.kpavlov.mokksy.MokksyServer
 import me.kpavlov.mokksy.ServerConfiguration
@@ -7,12 +8,14 @@ import me.kpavlov.mokksy.ServerConfiguration
 public abstract class AbstractMockLlm(
     port: Int = 0,
     configuration: ServerConfiguration,
+    applicationConfigurer: (Application.() -> Unit)? = null,
 ) {
     protected val mokksy: MokksyServer =
         MokksyServer(
             port = port,
             configuration = configuration,
         ) {
+            applicationConfigurer?.invoke(it)
             it.log.info("Running Mokksy with ${it.engine} engine")
         }
 


### PR DESCRIPTION
- feat(a2a): Add push notification handling 

    Introduced TaskNotificationHistory and NotificationListener classes to manage task-related notifications.
    Enhanced MockAgentServer with APIs for notification handling, including retrieving notifications and sending push notifications. Added tests to validate notification functionalities.
    
- docs(a2a): Update documentation