### PR TITLE
feat(core): add more matchers for request matching

### DIFF
--- a/ai-mocks-core/src/commonTest/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecificationTest.kt
+++ b/ai-mocks-core/src/commonTest/kotlin/me/kpavlov/aimocks/core/ChatRequestSpecificationTest.kt
@@ -2,6 +2,9 @@ package me.kpavlov.aimocks.core
 
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.include
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -53,4 +56,61 @@ class ChatRequestSpecificationTest {
             }
         }
     }
+
+    @Test
+    fun requestMatches() {
+        subject.requestMatches(include("world"))
+
+        subject.requestBody.first().let {
+            it.test("so, hello world etc") shouldNotBeNull {
+                passed() shouldBe true
+                failureMessage() shouldBe
+                    "\"so, hello world etc\" should include substring \"world\""
+                negatedFailureMessage() shouldStartWith
+                    "\"so, hello world etc\" should not include substring \"world\""
+            }
+            it.test("hello people") shouldNotBeNull {
+                passed() shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun requestMatchesPredicate() {
+        subject.requestMatchesPredicate {
+            it.contains("hello world")
+        }
+
+        subject.requestBody.first().let {
+            it.test("so, hello world etc") shouldNotBeNull {
+                passed() shouldBe true
+                failureMessage() shouldStartWith
+                    "Object 'so, hello world etc' should match predicate "
+                negatedFailureMessage() shouldStartWith
+                    "Object 'so, hello world etc' should NOT match predicate "
+            }
+            it.test("hello people and world") shouldNotBeNull {
+                passed() shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun requestSatisfies() {
+        subject.requestSatisfies { it shouldContain "world" }
+
+        subject.requestBody.first().let {
+            it.test("so, hello world etc") shouldNotBeNull {
+                passed() shouldBe true
+                failureMessage() shouldStartWith
+                    "Object 'so, hello world etc' should satisfy '"
+                negatedFailureMessage() shouldStartWith
+                    "Object 'so, hello world etc' should NOT satisfy '"
+            }
+            it.test("hello people") shouldNotBeNull {
+                passed() shouldBe false
+            }
+        }
+    }
+
 }

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/springai/ChatCompletionSpringAiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/springai/ChatCompletionSpringAiTest.kt
@@ -2,8 +2,10 @@ package me.kpavlov.aimocks.openai.springai
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.beOfType
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
+import me.kpavlov.aimocks.openai.ChatCompletionRequest
 import me.kpavlov.aimocks.openai.openai
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
@@ -20,6 +22,9 @@ internal class ChatCompletionSpringAiTest : AbstractSpringAiTest() {
             maxTokens = maxCompletionTokensValue
             systemMessageContains("helpful pirate")
             userMessageContains("say 'Hello!'")
+            requestMatchesPredicate {
+                !it.stream
+            }
         } responds {
             assistantContent = "Ahoy there, matey! Hello!"
             finishReason = "stop"
@@ -46,6 +51,10 @@ internal class ChatCompletionSpringAiTest : AbstractSpringAiTest() {
             maxTokens = maxCompletionTokensValue
             systemMessageContains("helpful pirate")
             userMessageContains("say 'Hello!'")
+            requestMatches(beOfType(ChatCompletionRequest::class))
+            requestSatisfies {
+                it?.stream shouldBe true
+            }
         } respondsStream {
             responseFlow =
                 flow {

--- a/docs/content/docs/mokksy/_index.md
+++ b/docs/content/docs/mokksy/_index.md
@@ -41,7 +41,6 @@ val serverUrl = mokksy.serverUrl
 mokksy.stop()
 ```
 
-
 ## Responding with Predefined Responses
 
 ### GET Request
@@ -120,6 +119,30 @@ assertThat(result.bodyAsText()).isEqualTo(expectedResponse)
 assertThat(result.headers["Location"]).isEqualTo("/things/$id")
 assertThat(result.headers["Foo"]).isEqualTo("bar")
 ```
+
+### Request Specification Matchers
+
+Mokksy provides various matcher types to specify conditions for matching incoming HTTP requests:
+
+* **Path Matchers**
+  * `path` - Exact match for request path
+  * Example: `path("/things")`
+
+* **Content Matchers**
+  * `bodyContains` - Checks if the body contains specific text
+  * Example: `bodyContains("value")` or `bodyString += contain("value")`
+
+* **Header Matchers**
+  * `containsHeader` - Checks if the request contains a specific header with value
+  * Example: `containsHeader("X-Request-ID", "RequestID")`
+
+* **Predicate Matchers**
+  * `predicateMatcher` - Custom predicate function to match against request body
+  * Example: `bodyMatchesPredicate { it?.name == "foo" }`
+
+* **Call Matchers**
+  * `successCallMatcher` - Matches if a function call with the request body succeeds
+  * Example: `requestSatisfies { input -> input.shouldNotBeNull() }`
 
 ## Server-Side Events (SSE) Response
 

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestMarchers.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/request/RequestMarchers.kt
@@ -50,7 +50,7 @@ public infix fun Headers.shouldNotHaveHeader(header: Pair<String, String>) {
  * @param predicate the predicate to evaluate objects against
  * @return a [Matcher] that applies the given predicate to objects for evaluation
  */
-internal fun <T> predicateMatcher(predicate: (T?) -> Boolean): Matcher<T?> =
+public fun <T> predicateMatcher(predicate: (T?) -> Boolean): Matcher<T?> =
     object : Matcher<T?> {
         override fun test(value: T?): MatcherResult =
             MatcherResult(
@@ -64,6 +64,39 @@ internal fun <T> predicateMatcher(predicate: (T?) -> Boolean): Matcher<T?> =
             )
 
         override fun toString(): String = "PredicateMatcher($predicate)"
+    }
+
+/**
+ * Creates a matcher that tests whether the specified function `call` can execute successfully
+ * without throwing an exception when invoked with a given input value.
+ *
+ * @param T The type of the input value being tested.
+ * @param call A function that performs an operation using the input value of type `T?`.
+ *             The matcher tests whether this function can execute successfully without errors.
+ * @return A [Matcher] that evaluates if the `call` function can successfully execute when invoked
+ *         with an input value of type `T?`.
+ */
+public fun <T> successCallMatcher(call: (T?) -> Unit): Matcher<T?> =
+    object : Matcher<T?> {
+        override fun test(value: T?): MatcherResult {
+            val passed = try {
+                call.invoke(value)
+                true
+            } catch (_: Throwable) {
+                false
+            }
+            return MatcherResult(
+                passed,
+                {
+                    "Object '$value' should satisfy '$call'"
+                },
+                {
+                    "Object '$value' should NOT satisfy '$call'"
+                },
+            )
+        }
+
+        override fun toString(): String = "successCallMatcher($call)"
     }
 
 internal fun pathEqual(expected: String): Matcher<String> =

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/request/RequestMarchersKtTest.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/request/RequestMarchersKtTest.kt
@@ -1,6 +1,8 @@
 package me.kpavlov.mokksy.request
 
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 import me.kpavlov.mokksy.Input
 import org.junit.jupiter.api.Test
 
@@ -25,6 +27,21 @@ class RequestMarchersKtTest {
                         "Object 'Input(name=foo)' should match predicate 'predicateToString'"
                     negatedFailureMessage() shouldBe
                         "Object 'Input(name=foo)' should NOT match predicate 'predicateToString'"
+                }
+            }
+    }@Test
+    fun `Should test successCallMatcher`() {
+        val input = Input("foo")
+
+        successCallMatcher<Input>{ input.shouldNotBeNull() }
+            .apply {
+                toString() shouldStartWith "successCallMatcher("
+                test(input).apply {
+                    passed() shouldBe true
+                    failureMessage() shouldStartWith
+                        "Object 'Input(name=foo)' should satisfy '"
+                    negatedFailureMessage() shouldStartWith
+                        "Object 'Input(name=foo)' should NOT satisfy '"
                 }
             }
     }


### PR DESCRIPTION
- Introduced new matcher functions (e.g., `successCallMatcher` and `predicateMatcher`) for enhanced request matching.
- Updated `ModelRequestSpecification` to support inline builder actions and custom predicate-based request matching.
- Update docs