### PR TITLE
refactor: Refactor response specifications

### DIFF
--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/AgentCardResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/AgentCardResponseSpecification.kt
@@ -3,7 +3,7 @@ package me.kpavlov.aimocks.a2a
 import me.kpavlov.aimocks.a2a.model.AgentCard
 import me.kpavlov.aimocks.a2a.model.AgentCardBuilder
 import me.kpavlov.aimocks.a2a.model.JSONRPCError
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -12,7 +12,7 @@ public class AgentCardResponseSpecification(
     public var card: AgentCard? = null,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<Nothing, AgentCard>(response = response, delay = delay) {
+) : AbstractResponseSpecification<Nothing, AgentCard>(response = response, delay = delay) {
     public fun card(block: AgentCardBuilder.() -> Unit) {
         this.card = AgentCardBuilder().apply(block).build()
     }

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/CancelTaskResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/CancelTaskResponseSpecification.kt
@@ -6,7 +6,7 @@ import me.kpavlov.aimocks.a2a.model.JSONRPCError
 import me.kpavlov.aimocks.a2a.model.RequestId
 import me.kpavlov.aimocks.a2a.model.Task
 import me.kpavlov.aimocks.a2a.model.TaskBuilder
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -16,7 +16,7 @@ public class CancelTaskResponseSpecification(
     public var result: Task? = null,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<CancelTaskRequest, CancelTaskResponse>(
+) : AbstractResponseSpecification<CancelTaskRequest, CancelTaskResponse>(
     response = response,
     delay = delay
 ) {

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskPushNotificationResponseSpecification.kt
@@ -5,7 +5,7 @@ import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationResponse
 import me.kpavlov.aimocks.a2a.model.JSONRPCError
 import me.kpavlov.aimocks.a2a.model.RequestId
 import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -15,7 +15,7 @@ public class GetTaskPushNotificationResponseSpecification(
     public var result: TaskPushNotificationConfig? = null,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<GetTaskPushNotificationRequest, GetTaskPushNotificationResponse>(
+) : AbstractResponseSpecification<GetTaskPushNotificationRequest, GetTaskPushNotificationResponse>(
     response = response,
     delay = delay
 )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetTaskResponseSpecification.kt
@@ -6,7 +6,7 @@ import me.kpavlov.aimocks.a2a.model.JSONRPCError
 import me.kpavlov.aimocks.a2a.model.RequestId
 import me.kpavlov.aimocks.a2a.model.Task
 import me.kpavlov.aimocks.a2a.model.TaskBuilder
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -16,7 +16,7 @@ public class GetTaskResponseSpecification(
     public var result: Task? = null,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<GetTaskRequest, GetTaskResponse>(
+) : AbstractResponseSpecification<GetTaskRequest, GetTaskResponse>(
     response = response,
     delay = delay
 ) {

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskResponseSpecification.kt
@@ -5,7 +5,7 @@ import me.kpavlov.aimocks.a2a.model.RequestId
 import me.kpavlov.aimocks.a2a.model.SendTaskRequest
 import me.kpavlov.aimocks.a2a.model.SendTaskResponse
 import me.kpavlov.aimocks.a2a.model.Task
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -15,4 +15,7 @@ public class SendTaskResponseSpecification(
     public var result: Task? = null,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<SendTaskRequest, SendTaskResponse>(response = response, delay = delay)
+) : AbstractResponseSpecification<SendTaskRequest, SendTaskResponse>(
+    response = response,
+    delay = delay
+)

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingResponseSpecification.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.stream.consumeAsFlow
 import me.kpavlov.aimocks.a2a.model.JSONRPCError
 import me.kpavlov.aimocks.a2a.model.SendTaskStreamingRequest
 import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import java.util.stream.Stream
 import kotlin.time.Duration
@@ -16,7 +16,7 @@ public class SendTaskStreamingResponseSpecification(
     public var delayBetweenChunks: Duration = Duration.ZERO,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<SendTaskStreamingRequest, String>(
+) : AbstractResponseSpecification<SendTaskStreamingRequest, String>(
     response = response,
     delay = delay
 ) {

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SetTaskPushNotificationResponseSpecification.kt
@@ -6,7 +6,7 @@ import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.SetTaskPushNotificationResponse
 import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
 import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfigBuilder
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -16,7 +16,7 @@ public class SetTaskPushNotificationResponseSpecification(
     public var result: TaskPushNotificationConfig? = null,
     public var error: JSONRPCError? = null,
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<SetTaskPushNotificationRequest, SetTaskPushNotificationResponse>(
+) : AbstractResponseSpecification<SetTaskPushNotificationRequest, SetTaskPushNotificationResponse>(
     response = response,
     delay = delay
 ) {

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/TaskResubscriptionResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/TaskResubscriptionResponseSpecification.kt
@@ -3,7 +3,7 @@ package me.kpavlov.aimocks.a2a
 import kotlinx.coroutines.flow.Flow
 import me.kpavlov.aimocks.a2a.model.TaskResubscriptionRequest
 import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
-import me.kpavlov.aimocks.core.StreamingResponseSpecification
+import me.kpavlov.aimocks.core.AbstractStreamingResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -15,7 +15,7 @@ public class TaskResubscriptionResponseSpecification(
     responseFlow: Flow<TaskUpdateEvent>? = null,
     delayBetweenChunks: Duration = Duration.ZERO,
     delay: Duration = Duration.ZERO,
-) : StreamingResponseSpecification<TaskResubscriptionRequest, TaskUpdateEvent, String>(
+) : AbstractStreamingResponseSpecification<TaskResubscriptionRequest, TaskUpdateEvent, String>(
     responseFlow = responseFlow,
     response = response,
     delayBetweenChunks = delayBetweenChunks,

--- a/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicMessagesResponseSpecification.kt
+++ b/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicMessagesResponseSpecification.kt
@@ -4,8 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import me.kpavlov.aimocks.anthropic.StreamingResponseHelper.randomIdString
 import me.kpavlov.aimocks.anthropic.model.Message
 import me.kpavlov.aimocks.anthropic.model.MessageCreateParams
-import me.kpavlov.aimocks.core.ResponseSpecification
-import me.kpavlov.aimocks.core.StreamingResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 
@@ -19,7 +18,10 @@ public class AnthropicMessagesResponseSpecification(
     public var delayBetweenChunks: Duration = Duration.ZERO,
     delay: Duration = Duration.ZERO,
     public var stopReason: String = "end_turn",
-) : ResponseSpecification<MessageCreateParams, Message>(response = response, delay = delay) {
+) : AbstractResponseSpecification<MessageCreateParams, Message>(
+    response = response,
+    delay = delay
+) {
     public fun assistantContent(content: String): AnthropicMessagesResponseSpecification =
         apply {
             this.assistantContent =
@@ -33,22 +35,3 @@ public class AnthropicMessagesResponseSpecification(
         }
 }
 
-@Suppress("LongParameterList")
-public class AnthropicStreamingChatResponseSpecification(
-    response: AbstractResponseDefinition<String>,
-    responseFlow: Flow<String>? = null,
-    responseChunks: List<String>? = null,
-    delayBetweenChunks: Duration = Duration.ZERO,
-    delay: Duration = Duration.ZERO,
-    public var stopReason: String = "end_turn",
-    /**
-     * Should send `[DONE]` at the end.
-     */
-    public var sendDone: Boolean = false,
-) : StreamingResponseSpecification<MessageCreateParams, String, String>(
-    response = response,
-    responseFlow = responseFlow,
-    responseChunks = responseChunks,
-    delayBetweenChunks = delayBetweenChunks,
-    delay = delay
-)

--- a/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicStreamingChatResponseSpecification.kt
+++ b/ai-mocks-anthropic/src/commonMain/kotlin/me/kpavlov/aimocks/anthropic/AnthropicStreamingChatResponseSpecification.kt
@@ -1,0 +1,27 @@
+package me.kpavlov.aimocks.anthropic
+
+import kotlinx.coroutines.flow.Flow
+import me.kpavlov.aimocks.anthropic.model.MessageCreateParams
+import me.kpavlov.aimocks.core.AbstractStreamingResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+@Suppress("LongParameterList")
+public class AnthropicStreamingChatResponseSpecification(
+    response: AbstractResponseDefinition<String>,
+    responseFlow: Flow<String>? = null,
+    responseChunks: List<String>? = null,
+    delayBetweenChunks: Duration = Duration.ZERO,
+    delay: Duration = Duration.ZERO,
+    public var stopReason: String = "end_turn",
+    /**
+     * Should send `[DONE]` at the end.
+     */
+    public var sendDone: Boolean = false,
+) : AbstractStreamingResponseSpecification<MessageCreateParams, String, String>(
+    response = response,
+    responseFlow = responseFlow,
+    responseChunks = responseChunks,
+    delayBetweenChunks = delayBetweenChunks,
+    delay = delay
+)

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractBuildingStep.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractBuildingStep.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
  * @property buildingStep A reference to the internally managed building step
  *                        for configuring mock response behavior.
  */
-public abstract class AbstractBuildingStep<P : Any, R : ResponseSpecification<P, *>>(
+public abstract class AbstractBuildingStep<P : Any, R : AbstractResponseSpecification<P, *>>(
     protected val mokksy: MokksyServer,
     protected val buildingStep: BuildingStep<P>,
 ) {
@@ -90,7 +90,7 @@ public abstract class AbstractBuildingStep<P : Any, R : ResponseSpecification<P,
     }
 }
 
-public abstract class AbstractStreamingBuildingStep<P : Any, R : ResponseSpecification<P, *>>(
+public abstract class AbstractStreamingBuildingStep<P : Any, R : AbstractResponseSpecification<P, *>>(
     mokksy: MokksyServer,
     buildingStep: BuildingStep<P>,
 ) : AbstractBuildingStep<P, R>(

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ResponseSpecification.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/ResponseSpecification.kt
@@ -4,15 +4,25 @@ import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
+public interface ResponseSpecification {
+    /**
+     * Sets the delay before sending the response (time to first token).
+     *
+     * @param delayMs The delay in milliseconds.
+     * @return This specification instance for method chaining.
+     */
+    public fun delayMillis(value: Long)
+}
+
 /**
  * @param P The type of the request body.
  * @param T The type of the response body.
  * @param delay delay to first token
  */
-public abstract class ResponseSpecification<P : Any, T : Any>(
+public abstract class AbstractResponseSpecification<P : Any, T : Any>(
     protected val response: AbstractResponseDefinition<T>,
     public var delay: Duration,
-) {
+) : ResponseSpecification {
 
     /**
      * Sets the delay before sending the response (time to first token).
@@ -20,7 +30,7 @@ public abstract class ResponseSpecification<P : Any, T : Any>(
      * @param delayMs The delay in milliseconds.
      * @return This specification instance for method chaining.
      */
-    public fun delayMillis(value: Long) {
+    public override fun delayMillis(value: Long) {
         this.delay = value.milliseconds
     }
 }

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/StreamingResponseSpecification.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/StreamingResponseSpecification.kt
@@ -6,39 +6,55 @@ import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import java.util.stream.Stream
 import kotlin.time.Duration
 
-/**
- * @param P The type of the request body.
- * @param T The type of the chunk element.
- * @param R The type of the response chunk.
- */
-public abstract class StreamingResponseSpecification<P : Any, T : Any, R : Any>(
-    response: AbstractResponseDefinition<R>,
-    public var responseFlow: Flow<T>?,
-    public var responseChunks: List<T>?,
-    public var delayBetweenChunks: Duration = Duration.ZERO,
-    delay: Duration = Duration.ZERO,
-) : ResponseSpecification<P,R>(response = response, delay=delay) {
 
+public interface StreamingResponseSpecification<T : Any> {
     /**
      * Sets the chunks of content for the streaming response.
      *
      * @param chunks The chunks of content to include in the streaming response.
      */
-    public open fun chunks(chunks: List<T>) {
+    public fun chunks(chunks: List<T>)
+
+    /**
+     * Sets the chunks of content for the streaming response.
+     *
+     * @param chunks The chunks of content to include in the streaming response.
+     * @return This specification instance for method chaining.
+     */
+    public fun chunks(vararg chunks: T)
+
+    public fun stream(stream: Stream<T>)
+}
+
+/**
+ * @param P The type of the request body.
+ * @param T The type of the chunk element.
+ * @param R The type of the response chunk.
+ */
+public abstract class AbstractStreamingResponseSpecification<P : Any, T : Any, R : Any>(
+    response: AbstractResponseDefinition<R>,
+    public var responseFlow: Flow<T>?,
+    public var responseChunks: List<T>?,
+    public var delayBetweenChunks: Duration = Duration.ZERO,
+    delay: Duration = Duration.ZERO,
+) : AbstractResponseSpecification<P, R>(response = response, delay = delay),
+    StreamingResponseSpecification<T> {
+
+    public override fun chunks(chunks: List<T>) {
         this.responseChunks = chunks
     }
 
     /**
      * Sets the chunks of content for the streaming response.
      *
-     * @param vararg chunks The chunks of content to include in the streaming response.
+     * @param chunks The chunks of content to include in the streaming response.
      * @return This specification instance for method chaining.
      */
-    public open fun chunks(vararg chunks: T) {
+    public override fun chunks(vararg chunks: T) {
         this.responseChunks = chunks.toList()
     }
 
-    public fun stream(stream: Stream<T>) {
+    public override fun stream(stream: Stream<T>) {
         responseFlow = stream.consumeAsFlow()
     }
 

--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/json/schema/serializers/PropertyDefinitionSerializer.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/json/schema/serializers/PropertyDefinitionSerializer.kt
@@ -30,7 +30,7 @@ public class PropertyDefinitionSerializer : KSerializer<PropertyDefinition> {
         require(jsonElement is JsonObject) { "Expected JSON object for PropertyDefinition" }
 
         // Check if it's a reference
-        if (jsonElement.containsKey("\$ref")) {
+        if (jsonElement.containsKey($$"$ref")) {
             return decoder.json.decodeFromJsonElement(
                 ReferencePropertyDefinition.serializer(),
                 jsonElement,

--- a/ai-mocks-core/src/jvmMain/kotlin/me/kpavlov/aimocks/core/StreamingResponseSpecification.jvm.kt
+++ b/ai-mocks-core/src/jvmMain/kotlin/me/kpavlov/aimocks/core/StreamingResponseSpecification.jvm.kt
@@ -3,6 +3,8 @@ package me.kpavlov.aimocks.core
 import kotlinx.coroutines.stream.consumeAsFlow
 import java.util.stream.Stream
 
-public fun <P : Any, T : Any, R : Any> StreamingResponseSpecification<P, T, R>.responseStream(stream: Stream<T>) {
+public fun <P : Any, T : Any, R : Any> AbstractStreamingResponseSpecification<P, T, R>.responseStream(
+    stream: Stream<T>
+) {
     responseFlow = stream.consumeAsFlow()
 }

--- a/ai-mocks-gemini/src/commonMain/kotlin/me/kpavlov/aimocks/gemini/content/GeminiContentResponseSpecification.kt
+++ b/ai-mocks-gemini/src/commonMain/kotlin/me/kpavlov/aimocks/gemini/content/GeminiContentResponseSpecification.kt
@@ -1,6 +1,6 @@
 package me.kpavlov.aimocks.gemini.content
 
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.aimocks.gemini.Candidate
 import me.kpavlov.aimocks.gemini.Content
 import me.kpavlov.aimocks.gemini.GenerateContentRequest
@@ -25,7 +25,7 @@ public class GeminiContentResponseSpecification(
     public var finishReason: String = "STOP",
     public var role: String = "model",
     delay: Duration = Duration.ZERO,
-) : ResponseSpecification<GenerateContentRequest, GenerateContentResponse>(
+) : AbstractResponseSpecification<GenerateContentRequest, GenerateContentResponse>(
     response = response,
     delay = delay
 ) {

--- a/ai-mocks-gemini/src/commonMain/kotlin/me/kpavlov/aimocks/gemini/content/GeminiStreamingContentResponseSpecification.kt
+++ b/ai-mocks-gemini/src/commonMain/kotlin/me/kpavlov/aimocks/gemini/content/GeminiStreamingContentResponseSpecification.kt
@@ -1,7 +1,7 @@
 package me.kpavlov.aimocks.gemini.content
 
 import kotlinx.coroutines.flow.Flow
-import me.kpavlov.aimocks.core.StreamingResponseSpecification
+import me.kpavlov.aimocks.core.AbstractStreamingResponseSpecification
 import me.kpavlov.aimocks.gemini.GenerateContentRequest
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
@@ -22,7 +22,7 @@ public class GeminiStreamingContentResponseSpecification(
     delayBetweenChunks: Duration = Duration.ZERO,
     delay: Duration = Duration.ZERO,
     public var finishReason: String = "STOP"
-) : StreamingResponseSpecification<GenerateContentRequest, String, String>(
+) : AbstractStreamingResponseSpecification<GenerateContentRequest, String, String>(
     response,
     responseFlow,
     responseChunks,

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiChatResponseSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiChatResponseSpecification.kt
@@ -1,6 +1,7 @@
 package me.kpavlov.aimocks.openai.completions
 
 import kotlinx.coroutines.flow.Flow
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.aimocks.core.ResponseSpecification
 import me.kpavlov.aimocks.openai.ChatCompletionRequest
 import me.kpavlov.aimocks.openai.ChatResponse
@@ -35,7 +36,7 @@ public class OpenaiChatResponseSpecification(
     public var delayBetweenChunks: Duration = Duration.ZERO,
     delay: Duration = Duration.ZERO,
     public var finishReason: String = "stop",
-) : ResponseSpecification<ChatCompletionRequest, ChatResponse>(
+) : AbstractResponseSpecification<ChatCompletionRequest, ChatResponse>(
     response = response,
     delay = delay,
 ) {

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiStreamingChatResponseSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiStreamingChatResponseSpecification.kt
@@ -1,8 +1,8 @@
 package me.kpavlov.aimocks.openai.completions
 
 import kotlinx.coroutines.flow.Flow
+import me.kpavlov.aimocks.core.AbstractStreamingResponseSpecification
 import me.kpavlov.aimocks.core.ResponseSpecification
-import me.kpavlov.aimocks.core.StreamingResponseSpecification
 import me.kpavlov.aimocks.openai.ChatCompletionRequest
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
 import kotlin.time.Duration
@@ -40,7 +40,7 @@ public class OpenaiStreamingChatResponseSpecification(
      * Should send `[DONE]` at the end.
      */
     public var sendDone: Boolean = false,
-) : StreamingResponseSpecification<ChatCompletionRequest, String, String>(
+) : AbstractStreamingResponseSpecification<ChatCompletionRequest, String, String>(
     response = response,
     responseFlow = responseFlow,
     responseChunks = responseChunks,

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesResponseSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/responses/OpenaiResponsesResponseSpecification.kt
@@ -1,7 +1,7 @@
 package me.kpavlov.aimocks.openai.responses
 
 import kotlinx.coroutines.flow.Flow
-import me.kpavlov.aimocks.core.ResponseSpecification
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
 import me.kpavlov.aimocks.openai.model.responses.CreateResponseRequest
 import me.kpavlov.aimocks.openai.model.responses.Response
 import me.kpavlov.mokksy.response.AbstractResponseDefinition
@@ -32,7 +32,7 @@ public class OpenaiResponsesResponseSpecification(
     public var delayBetweenChunks: Duration = Duration.ZERO,
     delay: Duration = Duration.ZERO,
     public var finishReason: String = "stop",
-) : ResponseSpecification<CreateResponseRequest, Response>(
+) : AbstractResponseSpecification<CreateResponseRequest, Response>(
     response = response,
     delay = delay
 ) {


### PR DESCRIPTION
Migrate existing ResponseSpecification implementations to AbstractResponseSpecification for better abstraction.