### PR TITLE
A2A update

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -45,6 +45,7 @@ development purposes.
 
 - Use `git mv` command when renaming files to preserve git history, if possible
 - Never commit or push changes to git automatically. It should be done manually.
+- Ensure new code follows existing code style and design patterns.
 
 ### Code Style
 
@@ -74,6 +75,7 @@ development purposes.
   with infix form assertions `shouldBe` instead of `assertEquals`.
 - Use Kotest's `withClue("<failure reason>")` to describe failure reasons, but only when the assertion is NOT obvious.
   Remove obvious cases for simplicity.
+- If multiple assertions are maid against nullable field, first check for null, e.g.: `params shoulNotBeNull { params.id shouldBe 1 }`
 - Use `assertSoftly(subject) { ... }` to perform multiple assertions. Never use `assertSoftly { }` to verify properties
   of
   different subjects, or when there is only one assertion per subject. Avoid using `assertSoftly(this) { ... }`

--- a/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/DefaultA2AClient.kt
+++ b/a2a-client/src/commonMain/kotlin/me/kpavlov/a2a/client/DefaultA2AClient.kt
@@ -204,8 +204,9 @@ public open class DefaultA2AClient(
         return sendStreamingMessage(request)
     }
 
-    public override fun sendStreamingMessage(request: SendStreamingMessageRequest): Flow<TaskUpdateEvent> =
-        receiveTaskUpdateEvents(request, requestConfigurer)
+    public override fun sendStreamingMessage(
+        request: SendStreamingMessageRequest,
+    ): Flow<TaskUpdateEvent> = receiveTaskUpdateEvents(request, requestConfigurer)
 
     override fun resubscribeToTask(id: TaskId): Flow<TaskUpdateEvent> {
         val request =

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/A2ARequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/A2ARequest.kt
@@ -11,16 +11,15 @@
  */
 package me.kpavlov.aimocks.a2a.model
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+
 public interface A2ARequest {
-    public data class A(
-        val jsonrpc: String = "2.0",
-        val id: Any? = null,
-        val method: String = "tasks/send",
-        val params: TaskSendParams,
-    ) : A2ARequest {
-        init {
-            require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
-            require(method == "tasks/send") { "method not constant value tasks/send - $method" }
-        }
-    }
+    @SerialName("jsonrpc")
+    @EncodeDefault
+    public val jsonrpc: String
+        get() = "2.0"
+    public val id: RequestId?
+    public val method: String
+//    public val params: Any
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentAuthenticationBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentAuthenticationBuilder.kt
@@ -64,8 +64,9 @@ public class AgentAuthenticationBuilder {
  * @param init The lambda to configure the agent authentication.
  * @return A new [AgentAuthentication] instance.
  */
-public inline fun agentAuthentication(init: AgentAuthenticationBuilder.() -> Unit): AgentAuthentication =
-    AgentAuthenticationBuilder().apply(init).build()
+public inline fun agentAuthentication(
+    init: AgentAuthenticationBuilder.() -> Unit,
+): AgentAuthentication = AgentAuthenticationBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [AgentAuthentication].
@@ -85,8 +86,9 @@ public fun agentAuthentication(init: Consumer<AgentAuthenticationBuilder>): Agen
  * @param block A configuration block for building an AgentAuthentication instance using the AgentAuthenticationBuilder.
  * @return A newly created AgentAuthentication instance.
  */
-public fun AgentAuthentication.Companion.create(block: AgentAuthenticationBuilder.() -> Unit): AgentAuthentication =
-    AgentAuthenticationBuilder().apply(block).build()
+public fun AgentAuthentication.Companion.create(
+    block: AgentAuthenticationBuilder.() -> Unit,
+): AgentAuthentication = AgentAuthenticationBuilder().apply(block).build()
 
 /**
  * Creates a new instance of an AgentAuthentication using the provided Java-friendly Consumer.
@@ -94,7 +96,9 @@ public fun AgentAuthentication.Companion.create(block: AgentAuthenticationBuilde
  * @param block A consumer for building an AgentAuthentication instance using the AgentAuthenticationBuilder.
  * @return A newly created AgentAuthentication instance.
  */
-public fun AgentAuthentication.Companion.create(block: Consumer<AgentAuthenticationBuilder>): AgentAuthentication {
+public fun AgentAuthentication.Companion.create(
+    block: Consumer<AgentAuthenticationBuilder>,
+): AgentAuthentication {
     val builder = AgentAuthenticationBuilder()
     block.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCapabilitiesBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCapabilitiesBuilder.kt
@@ -95,8 +95,9 @@ public fun agentCapabilities(init: Consumer<AgentCapabilitiesBuilder>): AgentCap
  * @param block A configuration block for building an AgentCapabilities instance using the AgentCapabilitiesBuilder.
  * @return A newly created AgentCapabilities instance.
  */
-public fun AgentCapabilities.Companion.create(block: AgentCapabilitiesBuilder.() -> Unit): AgentCapabilities =
-    AgentCapabilitiesBuilder().apply(block).build()
+public fun AgentCapabilities.Companion.create(
+    block: AgentCapabilitiesBuilder.() -> Unit,
+): AgentCapabilities = AgentCapabilitiesBuilder().apply(block).build()
 
 /**
  * Creates a new instance of an AgentCapabilities using the provided Java-friendly Consumer.
@@ -104,7 +105,9 @@ public fun AgentCapabilities.Companion.create(block: AgentCapabilitiesBuilder.()
  * @param block A consumer for building an AgentCapabilities instance using the AgentCapabilitiesBuilder.
  * @return A newly created AgentCapabilities instance.
  */
-public fun AgentCapabilities.Companion.create(block: Consumer<AgentCapabilitiesBuilder>): AgentCapabilities {
+public fun AgentCapabilities.Companion.create(
+    block: Consumer<AgentCapabilitiesBuilder>,
+): AgentCapabilities {
     val builder = AgentCapabilitiesBuilder()
     block.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCardBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentCardBuilder.kt
@@ -176,7 +176,9 @@ public class AgentCardBuilder {
      * @param supportsAuthenticatedExtendedCard Whether authenticated extended card is supported.
      * @return This builder instance for method chaining.
      */
-    public fun supportsAuthenticatedExtendedCard(supportsAuthenticatedExtendedCard: Boolean): AgentCardBuilder =
+    public fun supportsAuthenticatedExtendedCard(
+        supportsAuthenticatedExtendedCard: Boolean,
+    ): AgentCardBuilder =
         apply {
             this.supportsAuthenticatedExtendedCard = supportsAuthenticatedExtendedCard
         }
@@ -218,7 +220,8 @@ public class AgentCardBuilder {
      * @param block The lambda to configure the skill.
      * @return The created skill.
      */
-    public fun skill(block: AgentSkillBuilder.() -> Unit): AgentSkill = AgentSkillBuilder().apply(block).build()
+    public fun skill(block: AgentSkillBuilder.() -> Unit): AgentSkill =
+        AgentSkillBuilder().apply(block).build()
 
     /**
      * Creates a skill using the provided Java-friendly Consumer.
@@ -299,7 +302,8 @@ public class AgentCardBuilder {
  * @param init The lambda to configure the agent card.
  * @return A new [AgentCard] instance.
  */
-public inline fun agentCard(init: AgentCardBuilder.() -> Unit): AgentCard = AgentCardBuilder().apply(init).build()
+public inline fun agentCard(init: AgentCardBuilder.() -> Unit): AgentCard =
+    AgentCardBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [AgentCard].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkill.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkill.kt
@@ -36,6 +36,7 @@ public data class AgentSkill(
          * @param init The lambda to configure the agent skill.
          * @return A new AgentSkill instance.
          */
-        public fun build(init: AgentSkillBuilder.() -> Unit): AgentSkill = AgentSkillBuilder().apply(init).build()
+        public fun build(init: AgentSkillBuilder.() -> Unit): AgentSkill =
+            AgentSkillBuilder().apply(init).build()
     }
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkillBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AgentSkillBuilder.kt
@@ -149,7 +149,8 @@ public class AgentSkillBuilder {
  * @param init The lambda to configure the agent skill.
  * @return A new [AgentSkill] instance.
  */
-public inline fun agentSkill(init: AgentSkillBuilder.() -> Unit): AgentSkill = AgentSkillBuilder().apply(init).build()
+public inline fun agentSkill(init: AgentSkillBuilder.() -> Unit): AgentSkill =
+    AgentSkillBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [AgentSkill].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ArtifactBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ArtifactBuilder.kt
@@ -80,7 +80,8 @@ public class ArtifactBuilder {
      * @param block The lambda to configure the text part.
      * @return The created text part.
      */
-    public fun textPart(block: TextPartBuilder.() -> Unit): TextPart = TextPartBuilder().apply(block).build()
+    public fun textPart(block: TextPartBuilder.() -> Unit): TextPart =
+        TextPartBuilder().apply(block).build()
 
     /**
      * Creates a text part using the provided Java-friendly Consumer.
@@ -112,7 +113,8 @@ public class ArtifactBuilder {
      * @param block The lambda to configure the file part.
      * @return The created file part.
      */
-    public fun filePart(block: FilePartBuilder.() -> Unit): FilePart = FilePartBuilder().apply(block).build()
+    public fun filePart(block: FilePartBuilder.() -> Unit): FilePart =
+        FilePartBuilder().apply(block).build()
 
     /**
      * Creates a file part using the provided Java-friendly Consumer.
@@ -132,7 +134,8 @@ public class ArtifactBuilder {
      * @param block The lambda to configure the data part.
      * @return The created data part.
      */
-    public fun dataPart(block: DataPartBuilder.() -> Unit): DataPart = DataPartBuilder().apply(block).build()
+    public fun dataPart(block: DataPartBuilder.() -> Unit): DataPart =
+        DataPartBuilder().apply(block).build()
 
     /**
      * Creates a data part using the provided Java-friendly Consumer.
@@ -217,7 +220,8 @@ public class ArtifactBuilder {
  * @param init The lambda to configure the artifact.
  * @return A new [Artifact] instance.
  */
-public inline fun artifact(init: ArtifactBuilder.() -> Unit): Artifact = ArtifactBuilder().apply(init).build()
+public inline fun artifact(init: ArtifactBuilder.() -> Unit): Artifact =
+    ArtifactBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [Artifact].
@@ -237,7 +241,8 @@ public fun artifact(init: Consumer<ArtifactBuilder>): Artifact {
  * @param init The lambda to configure the artifact.
  * @return A new Artifact instance.
  */
-public fun Artifact.Companion.create(init: ArtifactBuilder.() -> Unit): Artifact = ArtifactBuilder().apply(init).build()
+public fun Artifact.Companion.create(init: ArtifactBuilder.() -> Unit): Artifact =
+    ArtifactBuilder().apply(init).build()
 
 /**
  * Creates a new Artifact using the provided Java-friendly Consumer.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AuthenticationInfoBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/AuthenticationInfoBuilder.kt
@@ -55,8 +55,9 @@ public class AuthenticationInfoBuilder {
  * @param init The lambda to configure the authentication info.
  * @return A new [AuthenticationInfo] instance.
  */
-public inline fun authenticationInfo(init: AuthenticationInfoBuilder.() -> Unit): AuthenticationInfo =
-    AuthenticationInfoBuilder().apply(init).build()
+public inline fun authenticationInfo(
+    init: AuthenticationInfoBuilder.() -> Unit,
+): AuthenticationInfo = AuthenticationInfoBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [AuthenticationInfo].
@@ -76,8 +77,9 @@ public fun authenticationInfo(init: Consumer<AuthenticationInfoBuilder>): Authen
  * @param init The lambda to configure the authentication info.
  * @return A new AuthenticationInfo instance.
  */
-public fun AuthenticationInfo.Companion.create(init: AuthenticationInfoBuilder.() -> Unit): AuthenticationInfo =
-    AuthenticationInfoBuilder().apply(init).build()
+public fun AuthenticationInfo.Companion.create(
+    init: AuthenticationInfoBuilder.() -> Unit,
+): AuthenticationInfo = AuthenticationInfoBuilder().apply(init).build()
 
 /**
  * Creates a new AuthenticationInfo using the provided Java-friendly Consumer.
@@ -85,7 +87,9 @@ public fun AuthenticationInfo.Companion.create(init: AuthenticationInfoBuilder.(
  * @param init A consumer for building an AuthenticationInfo instance using the AuthenticationInfoBuilder.
  * @return A newly created AuthenticationInfo instance.
  */
-public fun AuthenticationInfo.Companion.create(init: Consumer<AuthenticationInfoBuilder>): AuthenticationInfo {
+public fun AuthenticationInfo.Companion.create(
+    init: Consumer<AuthenticationInfoBuilder>,
+): AuthenticationInfo {
     val builder = AuthenticationInfoBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequest.kt
@@ -20,13 +20,13 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class CancelTaskRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    val id: RequestId? = null,
+    override val id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "tasks/cancel",
+    override val method: String = "tasks/cancel",
     @SerialName("params")
     val params: TaskIdParams,
 ) : A2ARequest {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskRequestBuilder.kt
@@ -88,8 +88,9 @@ public fun cancelTaskRequest(init: Consumer<CancelTaskRequestBuilder>): CancelTa
  * @param init The lambda to configure the cancel task request.
  * @return A new [CancelTaskRequest] instance.
  */
-public fun CancelTaskRequest.Companion.create(init: CancelTaskRequestBuilder.() -> Unit): CancelTaskRequest =
-    CancelTaskRequestBuilder().apply(init).build()
+public fun CancelTaskRequest.Companion.create(
+    init: CancelTaskRequestBuilder.() -> Unit,
+): CancelTaskRequest = CancelTaskRequestBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [CancelTaskRequest.Companion].
@@ -97,7 +98,9 @@ public fun CancelTaskRequest.Companion.create(init: CancelTaskRequestBuilder.() 
  * @param init The consumer to configure the cancel task request.
  * @return A new [CancelTaskRequest] instance.
  */
-public fun CancelTaskRequest.Companion.create(init: Consumer<CancelTaskRequestBuilder>): CancelTaskRequest {
+public fun CancelTaskRequest.Companion.create(
+    init: Consumer<CancelTaskRequestBuilder>,
+): CancelTaskRequest {
     val builder = CancelTaskRequestBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/CancelTaskResponseBuilder.kt
@@ -94,8 +94,9 @@ public class CancelTaskResponseBuilder {
  * @param init The lambda to configure the cancel task response.
  * @return A new [CancelTaskResponse] instance.
  */
-public inline fun cancelTaskResponse(init: CancelTaskResponseBuilder.() -> Unit): CancelTaskResponse =
-    CancelTaskResponseBuilder().apply(init).build()
+public inline fun cancelTaskResponse(
+    init: CancelTaskResponseBuilder.() -> Unit,
+): CancelTaskResponse = CancelTaskResponseBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [CancelTaskResponse].
@@ -115,8 +116,9 @@ public fun cancelTaskResponse(init: Consumer<CancelTaskResponseBuilder>): Cancel
  * @param init The lambda to configure the cancel task response.
  * @return A new [CancelTaskResponse] instance.
  */
-public fun CancelTaskResponse.Companion.create(init: CancelTaskResponseBuilder.() -> Unit): CancelTaskResponse =
-    CancelTaskResponseBuilder().apply(init).build()
+public fun CancelTaskResponse.Companion.create(
+    init: CancelTaskResponseBuilder.() -> Unit,
+): CancelTaskResponse = CancelTaskResponseBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [CancelTaskResponse.Companion].
@@ -124,7 +126,9 @@ public fun CancelTaskResponse.Companion.create(init: CancelTaskResponseBuilder.(
  * @param init The consumer to configure the cancel task response.
  * @return A new [CancelTaskResponse] instance.
  */
-public fun CancelTaskResponse.Companion.create(init: Consumer<CancelTaskResponseBuilder>): CancelTaskResponse {
+public fun CancelTaskResponse.Companion.create(
+    init: Consumer<CancelTaskResponseBuilder>,
+): CancelTaskResponse {
     val builder = CancelTaskResponseBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DataPartBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DataPartBuilder.kt
@@ -87,7 +87,8 @@ public class DataPartBuilder {
  * @param init The lambda to configure the data part
  * @return A new DataPart instance
  */
-public inline fun dataPart(init: DataPartBuilder.() -> Unit): DataPart = DataPartBuilder().apply(init).build()
+public inline fun dataPart(init: DataPartBuilder.() -> Unit): DataPart =
+    DataPartBuilder().apply(init).build()
 
 /**
  * Creates a new DataPart using the Java-friendly Consumer.
@@ -107,7 +108,8 @@ public fun dataPart(init: Consumer<DataPartBuilder>): DataPart {
  * @param init The lambda to configure the data part
  * @return A new DataPart instance
  */
-public fun DataPart.Companion.create(init: DataPartBuilder.() -> Unit): DataPart = DataPartBuilder().apply(init).build()
+public fun DataPart.Companion.create(init: DataPartBuilder.() -> Unit): DataPart =
+    DataPartBuilder().apply(init).build()
 
 /**
  * Creates a new DataPart using the Java-friendly Consumer.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigParams.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigParams.kt
@@ -1,0 +1,19 @@
+/*
+ * DeleteTaskPushNotificationConfigParams.kt
+ */
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * https://a2a-protocol.org/latest/specification/#781-deletetaskpushnotificationconfigparams-object-taskspushnotificationconfigdelete
+ */
+@Serializable
+public data class DeleteTaskPushNotificationConfigParams(
+    @SerialName("id")
+    val id: TaskId,
+    @SerialName("metadata")
+    val metadata: Map<String, JsonElement>? = null,
+)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigParamsBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigParamsBuilder.kt
@@ -1,0 +1,82 @@
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.json.JsonElement
+import java.util.function.Consumer
+
+/**
+ * DSL builder for [DeleteTaskPushNotificationConfigParams].
+ *
+ * Example usage:
+ * ```
+ * val params = deleteTaskPushNotificationConfigParams {
+ *     id = "task_12345"
+ * }
+ * ```
+ */
+public class DeleteTaskPushNotificationConfigParamsBuilder {
+    public var id: TaskId? = null
+    public var metadata: Map<String, JsonElement>? = null
+
+    /**
+     * Sets the ID of the task.
+     *
+     * @param id The ID of the task.
+     * @return This builder instance for method chaining.
+     */
+    public fun id(id: TaskId): DeleteTaskPushNotificationConfigParamsBuilder =
+        apply {
+            this.id = id
+        }
+
+    /**
+     * Sets the metadata for the request.
+     *
+     * @param metadata The metadata map.
+     * @return This builder instance for method chaining.
+     */
+    public fun metadata(
+        metadata: Map<String, JsonElement>,
+    ): DeleteTaskPushNotificationConfigParamsBuilder =
+        apply {
+            this.metadata = metadata
+        }
+
+    /**
+     * Builds a [DeleteTaskPushNotificationConfigParams] instance with the configured parameters.
+     *
+     * @return A new [DeleteTaskPushNotificationConfigParams] instance.
+     * @throws IllegalArgumentException if required fields are missing.
+     */
+    public fun build(): DeleteTaskPushNotificationConfigParams {
+          val id = requireNotNull(this.id) { "id is required" }
+          return DeleteTaskPushNotificationConfigParams(
+                  id = id,
+                  metadata = metadata,
+              )
+         }
+}
+
+/**
+ * Top-level DSL function for creating [DeleteTaskPushNotificationConfigParams].
+ *
+ * @param init The lambda to configure the delete task push notification config params.
+ * @return A new [DeleteTaskPushNotificationConfigParams] instance.
+ */
+public inline fun deleteTaskPushNotificationConfigParams(
+    init: DeleteTaskPushNotificationConfigParamsBuilder.() -> Unit,
+): DeleteTaskPushNotificationConfigParams =
+    DeleteTaskPushNotificationConfigParamsBuilder().apply(init).build()
+
+/**
+ * Java-friendly top-level DSL function for creating [DeleteTaskPushNotificationConfigParams].
+ *
+ * @param init The consumer to configure the delete task push notification config params.
+ * @return A new [DeleteTaskPushNotificationConfigParams] instance.
+ */
+public fun deleteTaskPushNotificationConfigParams(
+    init: Consumer<DeleteTaskPushNotificationConfigParamsBuilder>,
+): DeleteTaskPushNotificationConfigParams {
+    val builder = DeleteTaskPushNotificationConfigParamsBuilder()
+    init.accept(builder)
+    return builder.build()
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigRequest.kt
@@ -1,5 +1,5 @@
 /*
- * ListTaskPushNotificationConfigRequest.kt
+ * DeleteTaskPushNotificationConfigRequest.kt
  */
 package me.kpavlov.aimocks.a2a.model
 
@@ -9,10 +9,10 @@ import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
 /**
- * https://a2a-protocol.org/latest/specification/#77-taskspushnotificationconfiglist
+ * https://a2a-protocol.org/latest/specification/#78-taskspushnotificationconfigdelete
  */
 @Serializable
-public data class ListTaskPushNotificationConfigRequest(
+public data class DeleteTaskPushNotificationConfigRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
     override val jsonrpc: String = "2.0",
@@ -21,14 +21,14 @@ public data class ListTaskPushNotificationConfigRequest(
     override val id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    override val method: String = "tasks/pushNotificationConfig/list",
+    override val method: String = "tasks/pushNotificationConfig/delete",
     @SerialName("params")
-    val params: ListTaskPushNotificationConfigParams? = null,
+    val params: DeleteTaskPushNotificationConfigParams? = null,
 ) : A2ARequest {
     init {
         require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
-        require(method == "tasks/pushNotificationConfig/list") {
-            "method not constant value \"tasks/pushNotificationConfig/list\" - $method"
+        require(method == "tasks/pushNotificationConfig/delete") {
+            "method not constant value \"tasks/pushNotificationConfig/delete\" - $method"
         }
     }
 

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigRequestBuilder.kt
@@ -1,0 +1,121 @@
+package me.kpavlov.aimocks.a2a.model
+
+import java.util.function.Consumer
+
+/**
+ * DSL builder for [DeleteTaskPushNotificationConfigRequest].
+ *
+ * Example usage:
+ * ```
+ * val request = deleteTaskPushNotificationConfigRequest {
+ *     id = "1"
+ *     params {
+ *         id = "task_12345"
+ *     }
+ * }
+ * ```
+ */
+public class DeleteTaskPushNotificationConfigRequestBuilder {
+    public var id: RequestId? = null
+    public var params: DeleteTaskPushNotificationConfigParams? = null
+
+    /**
+     * Sets the ID of the request.
+     *
+     * @param id The ID of the request.
+     * @return This builder instance for method chaining.
+     */
+    public fun id(id: RequestId): DeleteTaskPushNotificationConfigRequestBuilder =
+        apply {
+            this.id = id
+        }
+
+    /**
+     * Configures the delete parameters using a lambda with receiver.
+     *
+     * @param init The lambda to configure the delete parameters.
+     * @return This builder instance for method chaining.
+     */
+    public fun params(
+        init: DeleteTaskPushNotificationConfigParamsBuilder.() -> Unit,
+    ): DeleteTaskPushNotificationConfigRequestBuilder =
+        apply {
+            params = DeleteTaskPushNotificationConfigParamsBuilder().apply(init).build()
+        }
+
+    /**
+     * Configures the delete parameters using a Java-friendly Consumer.
+     *
+     * @param init The consumer to configure the delete parameters.
+     * @return This builder instance for method chaining.
+     */
+    public fun params(
+        init: Consumer<DeleteTaskPushNotificationConfigParamsBuilder>,
+    ): DeleteTaskPushNotificationConfigRequestBuilder =
+        apply {
+            val builder = DeleteTaskPushNotificationConfigParamsBuilder()
+            init.accept(builder)
+            params = builder.build()
+        }
+
+    /**
+     * Builds a [DeleteTaskPushNotificationConfigRequest] instance with the configured parameters.
+     *
+     * @return A new [DeleteTaskPushNotificationConfigRequest] instance.
+     */
+    public fun build(): DeleteTaskPushNotificationConfigRequest =
+        DeleteTaskPushNotificationConfigRequest(
+            id = id,
+            params = params,
+        )
+}
+
+/**
+ * Top-level DSL function for creating [DeleteTaskPushNotificationConfigRequest].
+ *
+ * @param init The lambda to configure the delete task push notification config request.
+ * @return A new [DeleteTaskPushNotificationConfigRequest] instance.
+ */
+public inline fun deleteTaskPushNotificationConfigRequest(
+    init: DeleteTaskPushNotificationConfigRequestBuilder.() -> Unit,
+): DeleteTaskPushNotificationConfigRequest =
+    DeleteTaskPushNotificationConfigRequestBuilder().apply(init).build()
+
+/**
+ * Java-friendly top-level DSL function for creating [DeleteTaskPushNotificationConfigRequest].
+ *
+ * @param init The consumer to configure the delete task push notification config request.
+ * @return A new [DeleteTaskPushNotificationConfigRequest] instance.
+ */
+public fun deleteTaskPushNotificationConfigRequest(
+    init: Consumer<DeleteTaskPushNotificationConfigRequestBuilder>,
+): DeleteTaskPushNotificationConfigRequest {
+    val builder = DeleteTaskPushNotificationConfigRequestBuilder()
+    init.accept(builder)
+    return builder.build()
+}
+
+/**
+ * DSL extension for [DeleteTaskPushNotificationConfigRequest.Companion].
+ *
+ * @param init The lambda to configure the delete task push notification config request.
+ * @return A new [DeleteTaskPushNotificationConfigRequest] instance.
+ */
+public fun DeleteTaskPushNotificationConfigRequest.Companion.create(
+    init: DeleteTaskPushNotificationConfigRequestBuilder.() -> Unit,
+): DeleteTaskPushNotificationConfigRequest =
+    DeleteTaskPushNotificationConfigRequestBuilder().apply(init).build()
+
+/**
+ * Java-friendly DSL extension for [DeleteTaskPushNotificationConfigRequest.Companion].
+ *
+ * @param init The consumer to configure the delete task push notification config request.
+ * @return A new [DeleteTaskPushNotificationConfigRequest] instance.
+ */
+public fun DeleteTaskPushNotificationConfigRequest.Companion.create(
+    init: Consumer<DeleteTaskPushNotificationConfigRequestBuilder>,
+): DeleteTaskPushNotificationConfigRequest {
+    val builder = DeleteTaskPushNotificationConfigRequestBuilder()
+    init.accept(builder)
+    return builder.build()
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigResponse.kt
@@ -1,0 +1,34 @@
+/*
+ * DeleteTaskPushNotificationConfigResponse.kt
+ */
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
+
+/**
+ * https://a2a-protocol.org/latest/specification/#78-taskspushnotificationconfigdelete
+ */
+@Serializable
+public data class DeleteTaskPushNotificationConfigResponse(
+    @SerialName("jsonrpc")
+    @EncodeDefault
+    val jsonrpc: String = "2.0",
+    @SerialName("id")
+    @Serializable(with = RequestIdSerializer::class)
+    val id: RequestId? = null,
+    @SerialName("result")
+    @EncodeDefault(mode = EncodeDefault.Mode.NEVER)
+    val result: Nothing? = null,
+    @SerialName("error")
+    @EncodeDefault(mode = EncodeDefault.Mode.NEVER)
+    val error: JSONRPCError? = null,
+) {
+    init {
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+    }
+
+    public companion object
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/FilePartBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/FilePartBuilder.kt
@@ -97,7 +97,8 @@ public class FilePartBuilder {
  * @param init The lambda to configure the file part
  * @return A new FilePart instance
  */
-public inline fun filePart(init: FilePartBuilder.() -> Unit): FilePart = FilePartBuilder().apply(init).build()
+public inline fun filePart(init: FilePartBuilder.() -> Unit): FilePart =
+    FilePartBuilder().apply(init).build()
 
 /**
  * Creates a new FilePart using the Java-friendly Consumer.
@@ -117,7 +118,8 @@ public fun filePart(init: Consumer<FilePartBuilder>): FilePart {
  * @param init The lambda to configure the file part
  * @return A new FilePart instance
  */
-public fun FilePart.Companion.create(init: FilePartBuilder.() -> Unit): FilePart = FilePartBuilder().apply(init).build()
+public fun FilePart.Companion.create(init: FilePartBuilder.() -> Unit): FilePart =
+    FilePartBuilder().apply(init).build()
 
 /**
  * Creates a new FilePart using the Java-friendly Consumer.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetAuthenticatedExtendedCardRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetAuthenticatedExtendedCardRequest.kt
@@ -1,5 +1,5 @@
 /*
- * ListTaskPushNotificationConfigRequest.kt
+ * GetAuthenticatedExtendedCardRequest.kt
  */
 package me.kpavlov.aimocks.a2a.model
 
@@ -9,10 +9,10 @@ import kotlinx.serialization.Serializable
 import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 
 /**
- * https://a2a-protocol.org/latest/specification/#77-taskspushnotificationconfiglist
+ * https://a2a-protocol.org/latest/specification/#710-agentgetauthenticatedextendedcard
  */
 @Serializable
-public data class ListTaskPushNotificationConfigRequest(
+public data class GetAuthenticatedExtendedCardRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
     override val jsonrpc: String = "2.0",
@@ -21,14 +21,14 @@ public data class ListTaskPushNotificationConfigRequest(
     override val id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    override val method: String = "tasks/pushNotificationConfig/list",
+    override val method: String = "agent/getAuthenticatedExtendedCard",
     @SerialName("params")
-    val params: ListTaskPushNotificationConfigParams? = null,
+    val params: Nothing? = null,
 ) : A2ARequest {
     init {
         require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
-        require(method == "tasks/pushNotificationConfig/list") {
-            "method not constant value \"tasks/pushNotificationConfig/list\" - $method"
+        require(method == "agent/getAuthenticatedExtendedCard") {
+            "method not constant value \"agent/getAuthenticatedExtendedCard\" - $method"
         }
     }
 

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetAuthenticatedExtendedCardRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetAuthenticatedExtendedCardRequestBuilder.kt
@@ -1,0 +1,88 @@
+package me.kpavlov.aimocks.a2a.model
+
+import java.util.function.Consumer
+
+/**
+ * DSL builder for [GetAuthenticatedExtendedCardRequest].
+ *
+ * Example usage:
+ * ```
+ * val request = getAuthenticatedExtendedCardRequest {
+ *     id = "1"
+ * }
+ * ```
+ */
+public class GetAuthenticatedExtendedCardRequestBuilder {
+    public var id: RequestId? = null
+
+    /**
+     * Sets the ID of the request.
+     *
+     * @param id The ID of the request.
+     * @return This builder instance for method chaining.
+     */
+    public fun id(id: RequestId): GetAuthenticatedExtendedCardRequestBuilder =
+        apply {
+            this.id = id
+        }
+
+    /**
+     * Builds a [GetAuthenticatedExtendedCardRequest] instance with the configured parameters.
+     *
+     * @return A new [GetAuthenticatedExtendedCardRequest] instance.
+     */
+    public fun build(): GetAuthenticatedExtendedCardRequest =
+        GetAuthenticatedExtendedCardRequest(
+            id = id,
+        )
+}
+
+/**
+ * Top-level DSL function for creating [GetAuthenticatedExtendedCardRequest].
+ *
+ * @param init The lambda to configure the get authenticated extended card request.
+ * @return A new [GetAuthenticatedExtendedCardRequest] instance.
+ */
+public inline fun getAuthenticatedExtendedCardRequest(
+    init: GetAuthenticatedExtendedCardRequestBuilder.() -> Unit,
+): GetAuthenticatedExtendedCardRequest =
+    GetAuthenticatedExtendedCardRequestBuilder().apply(init).build()
+
+/**
+ * Java-friendly top-level DSL function for creating [GetAuthenticatedExtendedCardRequest].
+ *
+ * @param init The consumer to configure the get authenticated extended card request.
+ * @return A new [GetAuthenticatedExtendedCardRequest] instance.
+ */
+public fun getAuthenticatedExtendedCardRequest(
+    init: Consumer<GetAuthenticatedExtendedCardRequestBuilder>,
+): GetAuthenticatedExtendedCardRequest {
+    val builder = GetAuthenticatedExtendedCardRequestBuilder()
+    init.accept(builder)
+    return builder.build()
+}
+
+/**
+ * DSL extension for [GetAuthenticatedExtendedCardRequest.Companion].
+ *
+ * @param init The lambda to configure the get authenticated extended card request.
+ * @return A new [GetAuthenticatedExtendedCardRequest] instance.
+ */
+public fun GetAuthenticatedExtendedCardRequest.Companion.create(
+    init: GetAuthenticatedExtendedCardRequestBuilder.() -> Unit,
+): GetAuthenticatedExtendedCardRequest =
+    GetAuthenticatedExtendedCardRequestBuilder().apply(init).build()
+
+/**
+ * Java-friendly DSL extension for [GetAuthenticatedExtendedCardRequest.Companion].
+ *
+ * @param init The consumer to configure the get authenticated extended card request.
+ * @return A new [GetAuthenticatedExtendedCardRequest] instance.
+ */
+public fun GetAuthenticatedExtendedCardRequest.Companion.create(
+    init: Consumer<GetAuthenticatedExtendedCardRequestBuilder>,
+): GetAuthenticatedExtendedCardRequest {
+    val builder = GetAuthenticatedExtendedCardRequestBuilder()
+    init.accept(builder)
+    return builder.build()
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetAuthenticatedExtendedCardResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetAuthenticatedExtendedCardResponse.kt
@@ -1,0 +1,35 @@
+/*
+ * GetAuthenticatedExtendedCardResponse.kt
+ */
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
+
+/**
+ * https://a2a-protocol.org/latest/specification/#710-agentgetauthenticatedextendedcard
+ */
+@Serializable
+public data class GetAuthenticatedExtendedCardResponse(
+    @SerialName("jsonrpc")
+    @EncodeDefault
+    val jsonrpc: String = "2.0",
+    @SerialName("id")
+    @Serializable(with = RequestIdSerializer::class)
+    val id: RequestId? = null,
+    @SerialName("result")
+    val result: AgentCard? = null,
+    @SerialName("error")
+    val error: JSONRPCError? = null,
+) {
+    init {
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require((result == null) xor (error == null)) {
+            "Either result or error must be present, but not both"
+        }
+    }
+
+    public companion object
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationRequest.kt
@@ -20,13 +20,13 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class GetTaskPushNotificationRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    val id: RequestId? = null,
+    override val id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "tasks/pushNotificationConfig/get",
+    override val method: String = "tasks/pushNotificationConfig/get",
     @SerialName("params")
     val params: TaskIdParams,
 ) : A2ARequest {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskPushNotificationResponseBuilder.kt
@@ -46,7 +46,9 @@ public class GetTaskPushNotificationResponseBuilder {
      * @param init The lambda to configure the task push notification config.
      * @return This builder instance for method chaining.
      */
-    public fun result(init: TaskPushNotificationConfigBuilder.() -> Unit): GetTaskPushNotificationResponseBuilder =
+    public fun result(
+        init: TaskPushNotificationConfigBuilder.() -> Unit,
+    ): GetTaskPushNotificationResponseBuilder =
         apply {
             result = TaskPushNotificationConfig.create(init)
         }
@@ -57,7 +59,9 @@ public class GetTaskPushNotificationResponseBuilder {
      * @param init The consumer to configure the task push notification config.
      * @return This builder instance for method chaining.
      */
-    public fun result(init: Consumer<TaskPushNotificationConfigBuilder>): GetTaskPushNotificationResponseBuilder =
+    public fun result(
+        init: Consumer<TaskPushNotificationConfigBuilder>,
+    ): GetTaskPushNotificationResponseBuilder =
         apply {
             val builder = TaskPushNotificationConfigBuilder()
             init.accept(builder)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskRequest.kt
@@ -20,16 +20,16 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class GetTaskRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    val id: RequestId? = null,
+    override val id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "tasks/get",
+    override val method: String = "tasks/get",
     @SerialName("params")
     val params: TaskQueryParams,
-) : A2ARequest {
+) : A2ARequest{
     init {
         require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
         require(method == "tasks/get") { "method not constant value tasks/get - $method" }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/GetTaskResponseBuilder.kt
@@ -115,8 +115,9 @@ public fun getTaskResponse(init: Consumer<GetTaskResponseBuilder>): GetTaskRespo
  * @param init The lambda to configure the get task response.
  * @return A new [GetTaskResponse] instance.
  */
-public fun GetTaskResponse.Companion.create(init: GetTaskResponseBuilder.() -> Unit): GetTaskResponse =
-    GetTaskResponseBuilder().apply(init).build()
+public fun GetTaskResponse.Companion.create(
+    init: GetTaskResponseBuilder.() -> Unit,
+): GetTaskResponse = GetTaskResponseBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [GetTaskResponse.Companion].
@@ -124,7 +125,9 @@ public fun GetTaskResponse.Companion.create(init: GetTaskResponseBuilder.() -> U
  * @param init The consumer to configure the get task response.
  * @return A new [GetTaskResponse] instance.
  */
-public fun GetTaskResponse.Companion.create(init: Consumer<GetTaskResponseBuilder>): GetTaskResponse {
+public fun GetTaskResponse.Companion.create(
+    init: Consumer<GetTaskResponseBuilder>,
+): GetTaskResponse {
     val builder = GetTaskResponseBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidParamsErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidParamsErrorBuilder.kt
@@ -12,7 +12,8 @@ import java.util.function.Consumer
  * }
  * ```
  */
-public class InvalidParamsErrorBuilder : JSONRPCErrorBuilder<InvalidParamsError, InvalidParamsErrorBuilder>() {
+public class InvalidParamsErrorBuilder :
+    JSONRPCErrorBuilder<InvalidParamsError, InvalidParamsErrorBuilder>() {
     /**
      * Builds an [InvalidParamsError] instance with the configured parameters.
      *
@@ -30,8 +31,9 @@ public class InvalidParamsErrorBuilder : JSONRPCErrorBuilder<InvalidParamsError,
  * @param init The lambda to configure the invalid params error.
  * @return A new [InvalidParamsError] instance.
  */
-public inline fun invalidParamsError(init: InvalidParamsErrorBuilder.() -> Unit): InvalidParamsError =
-    InvalidParamsErrorBuilder().apply(init).build()
+public inline fun invalidParamsError(
+    init: InvalidParamsErrorBuilder.() -> Unit,
+): InvalidParamsError = InvalidParamsErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [InvalidParamsError].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidRequestErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/InvalidRequestErrorBuilder.kt
@@ -12,7 +12,8 @@ import java.util.function.Consumer
  * }
  * ```
  */
-public class InvalidRequestErrorBuilder : JSONRPCErrorBuilder<InvalidRequestError, InvalidRequestErrorBuilder>() {
+public class InvalidRequestErrorBuilder :
+    JSONRPCErrorBuilder<InvalidRequestError, InvalidRequestErrorBuilder>() {
     /**
      * Builds an [InvalidRequestError] instance with the configured parameters.
      *
@@ -30,8 +31,9 @@ public class InvalidRequestErrorBuilder : JSONRPCErrorBuilder<InvalidRequestErro
  * @param init The lambda to configure the invalid request error.
  * @return A new [InvalidRequestError] instance.
  */
-public inline fun invalidRequestError(init: InvalidRequestErrorBuilder.() -> Unit): InvalidRequestError =
-    InvalidRequestErrorBuilder().apply(init).build()
+public inline fun invalidRequestError(
+    init: InvalidRequestErrorBuilder.() -> Unit,
+): InvalidRequestError = InvalidRequestErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [InvalidRequestError].
@@ -51,8 +53,9 @@ public fun invalidRequestError(init: Consumer<InvalidRequestErrorBuilder>): Inva
  * @param init The lambda to configure the invalid request error.
  * @return A new [InvalidRequestError] instance.
  */
-public fun InvalidRequestError.Companion.create(init: InvalidRequestErrorBuilder.() -> Unit): InvalidRequestError =
-    InvalidRequestErrorBuilder().apply(init).build()
+public fun InvalidRequestError.Companion.create(
+    init: InvalidRequestErrorBuilder.() -> Unit,
+): InvalidRequestError = InvalidRequestErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [InvalidRequestError.Companion].
@@ -60,7 +63,9 @@ public fun InvalidRequestError.Companion.create(init: InvalidRequestErrorBuilder
  * @param init The consumer to configure the invalid request error.
  * @return A new [InvalidRequestError] instance.
  */
-public fun InvalidRequestError.Companion.create(init: Consumer<InvalidRequestErrorBuilder>): InvalidRequestError {
+public fun InvalidRequestError.Companion.create(
+    init: Consumer<InvalidRequestErrorBuilder>,
+): InvalidRequestError {
     val builder = InvalidRequestErrorBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCRequest.kt
@@ -35,9 +35,10 @@ public open class JSONRPCRequest<T>(
         require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
     }
 
-    public constructor(method: String, params: T? = null) : this(
+    public constructor(method: String, id: RequestId? = null, params: T? = null) : this(
         jsonrpc = "2.0",
         method = method,
+        id = id,
         params = params,
     )
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/JSONRPCResponseBuilder.kt
@@ -91,8 +91,9 @@ public fun jsonRPCResponse(init: Consumer<JSONRPCResponseBuilder>): JSONRPCRespo
  * @param init The lambda to configure the JSON-RPC response.
  * @return A new [JSONRPCResponse] instance.
  */
-public fun JSONRPCResponse.Companion.create(init: JSONRPCResponseBuilder.() -> Unit): JSONRPCResponse =
-    JSONRPCResponseBuilder().apply(init).build()
+public fun JSONRPCResponse.Companion.create(
+    init: JSONRPCResponseBuilder.() -> Unit,
+): JSONRPCResponse = JSONRPCResponseBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [JSONRPCResponse.Companion].
@@ -100,7 +101,9 @@ public fun JSONRPCResponse.Companion.create(init: JSONRPCResponseBuilder.() -> U
  * @param init The consumer to configure the JSON-RPC response.
  * @return A new [JSONRPCResponse] instance.
  */
-public fun JSONRPCResponse.Companion.create(init: Consumer<JSONRPCResponseBuilder>): JSONRPCResponse {
+public fun JSONRPCResponse.Companion.create(
+    init: Consumer<JSONRPCResponseBuilder>,
+): JSONRPCResponse {
     val builder = JSONRPCResponseBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigParams.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigParams.kt
@@ -1,0 +1,24 @@
+/*
+ * ListTaskPushNotificationConfigParams.kt
+ */
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Parameters for listing push notification configurations
+ * https://a2a-protocol.org/latest/specification/#77-taskspushnotificationconfiglist
+ */
+@Serializable
+public data class ListTaskPushNotificationConfigParams(
+    @SerialName("limit")
+    @EncodeDefault
+    val limit: Int? = null,
+    @SerialName("offset")
+    @EncodeDefault
+    val offset: Int? = null,
+) {
+    public companion object
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigParamsBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigParamsBuilder.kt
@@ -1,0 +1,76 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * DSL builder for [ListTaskPushNotificationConfigParams].
+ *
+ * Example usage:
+ * ```
+ * val params = listTaskPushNotificationConfigParams {
+ *     limit = 10
+ *     offset = 0
+ * }
+ * ```
+ */
+public class ListTaskPushNotificationConfigParamsBuilder {
+    public var limit: Int? = null
+    public var offset: Int? = null
+
+    /**
+     * Sets the limit for the number of configurations to return.
+     *
+     * @param limit The maximum number of configurations to return.
+     * @return This builder instance for method chaining.
+     */
+    public fun limit(limit: Int): ListTaskPushNotificationConfigParamsBuilder =
+        apply {
+            this.limit = limit
+        }
+
+    /**
+     * Sets the offset for pagination.
+     *
+     * @param offset The number of configurations to skip.
+     * @return This builder instance for method chaining.
+     */
+    public fun offset(offset: Int): ListTaskPushNotificationConfigParamsBuilder =
+        apply {
+            this.offset = offset
+        }
+
+    /**
+     * Builds a [ListTaskPushNotificationConfigParams] instance with the configured parameters.
+     *
+     * @return A new [ListTaskPushNotificationConfigParams] instance.
+     */
+    public fun build(): ListTaskPushNotificationConfigParams =
+        ListTaskPushNotificationConfigParams(
+            limit = limit,
+            offset = offset,
+        )
+}
+
+/**
+ * Top-level DSL function for creating [ListTaskPushNotificationConfigParams].
+ *
+ * @param init The lambda to configure the list task push notification config params.
+ * @return A new [ListTaskPushNotificationConfigParams] instance.
+ */
+public inline fun listTaskPushNotificationConfigParams(
+    init: ListTaskPushNotificationConfigParamsBuilder.() -> Unit,
+): ListTaskPushNotificationConfigParams =
+    ListTaskPushNotificationConfigParamsBuilder()
+        .apply(init)
+        .build()
+
+/**
+ * DSL extension for [ListTaskPushNotificationConfigParams.Companion].
+ *
+ * @param init The lambda to configure the list task push notification config params.
+ * @return A new [ListTaskPushNotificationConfigParams] instance.
+ */
+public fun ListTaskPushNotificationConfigParams.Companion.create(
+    init: ListTaskPushNotificationConfigParamsBuilder.() -> Unit,
+): ListTaskPushNotificationConfigParams =
+    ListTaskPushNotificationConfigParamsBuilder()
+        .apply(init)
+        .build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigRequest.kt
@@ -1,0 +1,36 @@
+/*
+ * ListTaskPushNotificationConfigRequest.kt
+ */
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
+
+/**
+ * https://a2a-protocol.org/latest/specification/#77-taskspushnotificationconfiglist
+ */
+@Serializable
+public data class ListTaskPushNotificationConfigRequest(
+    @SerialName("jsonrpc")
+    @EncodeDefault
+    val jsonrpc: String = "2.0",
+    @SerialName("id")
+    @Serializable(with = RequestIdSerializer::class)
+    val id: RequestId? = null,
+    @SerialName("method")
+    @EncodeDefault
+    val method: String = "tasks/pushNotificationConfig/list",
+    @SerialName("params")
+    val params: ListTaskPushNotificationConfigParams? = null,
+) : A2ARequest {
+    init {
+        require(jsonrpc == "2.0") { "jsonrpc not constant value 2.0 - $jsonrpc" }
+        require(method == "tasks/pushNotificationConfig/list") {
+            "method not constant value \"tasks/pushNotificationConfig/list\" - $method"
+        }
+    }
+
+    public companion object
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigRequestBuilder.kt
@@ -1,0 +1,122 @@
+package me.kpavlov.aimocks.a2a.model
+
+import java.util.function.Consumer
+
+/**
+ * DSL builder for [ListTaskPushNotificationConfigRequest].
+ *
+ * Example usage:
+ * ```
+ * val request = listTaskPushNotificationConfigRequest {
+ *     id = "1"
+ *     params {
+ *         limit = 10
+ *         offset = 0
+ *     }
+ * }
+ * ```
+ */
+public class ListTaskPushNotificationConfigRequestBuilder {
+    public var id: RequestId? = null
+    public var params: ListTaskPushNotificationConfigParams? = null
+
+    /**
+     * Sets the ID of the request.
+     *
+     * @param id The ID of the request.
+     * @return This builder instance for method chaining.
+     */
+    public fun id(id: RequestId): ListTaskPushNotificationConfigRequestBuilder =
+        apply {
+            this.id = id
+        }
+
+    /**
+     * Configures the list parameters using a lambda with receiver.
+     *
+     * @param init The lambda to configure the list parameters.
+     * @return This builder instance for method chaining.
+     */
+    public fun params(
+        init: ListTaskPushNotificationConfigParamsBuilder.() -> Unit,
+    ): ListTaskPushNotificationConfigRequestBuilder =
+        apply {
+            params = ListTaskPushNotificationConfigParamsBuilder().apply(init).build()
+        }
+
+    /**
+     * Configures the list parameters using a Java-friendly Consumer.
+     *
+     * @param init The consumer to configure the list parameters.
+     * @return This builder instance for method chaining.
+     */
+    public fun params(
+        init: Consumer<ListTaskPushNotificationConfigParamsBuilder>,
+    ): ListTaskPushNotificationConfigRequestBuilder =
+        apply {
+            val builder = ListTaskPushNotificationConfigParamsBuilder()
+            init.accept(builder)
+            params = builder.build()
+        }
+
+    /**
+     * Builds a [ListTaskPushNotificationConfigRequest] instance with the configured parameters.
+     *
+     * @return A new [ListTaskPushNotificationConfigRequest] instance.
+     */
+    public fun build(): ListTaskPushNotificationConfigRequest =
+        ListTaskPushNotificationConfigRequest(
+            id = id,
+            params = params,
+        )
+}
+
+/**
+ * Top-level DSL function for creating [ListTaskPushNotificationConfigRequest].
+ *
+ * @param init The lambda to configure the list task push notification config request.
+ * @return A new [ListTaskPushNotificationConfigRequest] instance.
+ */
+public inline fun listTaskPushNotificationConfigRequest(
+    init: ListTaskPushNotificationConfigRequestBuilder.() -> Unit,
+): ListTaskPushNotificationConfigRequest =
+    ListTaskPushNotificationConfigRequestBuilder().apply(init).build()
+
+/**
+ * Java-friendly top-level DSL function for creating [ListTaskPushNotificationConfigRequest].
+ *
+ * @param init The consumer to configure the list task push notification config request.
+ * @return A new [ListTaskPushNotificationConfigRequest] instance.
+ */
+public fun listTaskPushNotificationConfigRequest(
+    init: Consumer<ListTaskPushNotificationConfigRequestBuilder>,
+): ListTaskPushNotificationConfigRequest {
+    val builder = ListTaskPushNotificationConfigRequestBuilder()
+    init.accept(builder)
+    return builder.build()
+}
+
+/**
+ * DSL extension for [ListTaskPushNotificationConfigRequest.Companion].
+ *
+ * @param init The lambda to configure the list task push notification config request.
+ * @return A new [ListTaskPushNotificationConfigRequest] instance.
+ */
+public fun ListTaskPushNotificationConfigRequest.Companion.create(
+    init: ListTaskPushNotificationConfigRequestBuilder.() -> Unit,
+): ListTaskPushNotificationConfigRequest =
+    ListTaskPushNotificationConfigRequestBuilder().apply(init).build()
+
+/**
+ * Java-friendly DSL extension for [ListTaskPushNotificationConfigRequest.Companion].
+ *
+ * @param init The consumer to configure the list task push notification config request.
+ * @return A new [ListTaskPushNotificationConfigRequest] instance.
+ */
+public fun ListTaskPushNotificationConfigRequest.Companion.create(
+    init: Consumer<ListTaskPushNotificationConfigRequestBuilder>,
+): ListTaskPushNotificationConfigRequest {
+    val builder = ListTaskPushNotificationConfigRequestBuilder()
+    init.accept(builder)
+    return builder.build()
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigResponse.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigResponse.kt
@@ -1,0 +1,32 @@
+/*
+ * ListTaskPushNotificationConfigResponse.kt
+ */
+package me.kpavlov.aimocks.a2a.model
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
+
+/**
+ * https://a2a-protocol.org/latest/specification/#77-taskspushnotificationconfiglist
+ */
+@Serializable
+public data class ListTaskPushNotificationConfigResponse(
+    @SerialName("jsonrpc")
+    @EncodeDefault
+    val jsonrpc: String = "2.0",
+    @SerialName("id")
+    @Serializable(with = RequestIdSerializer::class)
+    val id: RequestId? = null,
+    @SerialName("result")
+    val result: List<TaskPushNotificationConfig>? = null,
+    @SerialName("error")
+    val error: JSONRPCError? = null,
+) {
+    init {
+        require(jsonrpc == "2.0") { "jsonrpc not constant value '2.0' - $jsonrpc" }
+    }
+
+    public companion object
+}

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/ListTaskPushNotificationConfigResponseBuilder.kt
@@ -1,0 +1,87 @@
+package me.kpavlov.aimocks.a2a.model
+
+/**
+ * DSL builder for [ListTaskPushNotificationConfigResponse].
+ *
+ * Example usage:
+ * ```
+ * val response = listTaskPushNotificationConfigResponse {
+ *     id = "1"
+ *     result = listOf(taskConfig1, taskConfig2)
+ * }
+ * ```
+ */
+public class ListTaskPushNotificationConfigResponseBuilder {
+    public var id: RequestId? = null
+    public var result: List<TaskPushNotificationConfig>? = null
+    public var error: JSONRPCError? = null
+
+    /**
+     * Sets the ID of the response.
+     *
+     * @param id The ID of the response.
+     * @return This builder instance for method chaining.
+     */
+    public fun id(id: RequestId): ListTaskPushNotificationConfigResponseBuilder =
+        apply {
+            this.id = id
+        }
+
+    /**
+     * Sets the result list of task push notification configs.
+     *
+     * @param result The list of task push notification config results.
+     * @return This builder instance for method chaining.
+     */
+    public fun result(
+        result: List<TaskPushNotificationConfig>,
+    ): ListTaskPushNotificationConfigResponseBuilder =
+        apply {
+            this.result = result
+        }
+
+    /**
+     * Sets the error for the response.
+     *
+     * @param error The JSON-RPC error.
+     * @return This builder instance for method chaining.
+     */
+    public fun error(error: JSONRPCError): ListTaskPushNotificationConfigResponseBuilder =
+        apply {
+            this.error = error
+        }
+
+    /**
+     * Builds a [ListTaskPushNotificationConfigResponse] instance with the configured parameters.
+     *
+     * @return A new [ListTaskPushNotificationConfigResponse] instance.
+     */
+    public fun build(): ListTaskPushNotificationConfigResponse =
+        ListTaskPushNotificationConfigResponse(
+            id = id,
+            result = result,
+            error = error,
+        )
+}
+
+/**
+ * Top-level DSL function for creating [ListTaskPushNotificationConfigResponse].
+ *
+ * @param init The lambda to configure the list task push notification config response.
+ * @return A new [ListTaskPushNotificationConfigResponse] instance.
+ */
+public inline fun listTaskPushNotificationConfigResponse(
+    init: ListTaskPushNotificationConfigResponseBuilder.() -> Unit,
+): ListTaskPushNotificationConfigResponse =
+    ListTaskPushNotificationConfigResponseBuilder().apply(init).build()
+
+/**
+ * DSL extension for [ListTaskPushNotificationConfigResponse.Companion].
+ *
+ * @param init The lambda to configure the list task push notification config response.
+ * @return A new [ListTaskPushNotificationConfigResponse] instance.
+ */
+public fun ListTaskPushNotificationConfigResponse.Companion.create(
+    init: ListTaskPushNotificationConfigResponseBuilder.() -> Unit,
+): ListTaskPushNotificationConfigResponse =
+    ListTaskPushNotificationConfigResponseBuilder().apply(init).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/MessageBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/MessageBuilder.kt
@@ -48,7 +48,8 @@ public class MessageBuilder {
         return this
     }
 
-    public fun textPart(block: TextPartBuilder.() -> Unit): TextPart = TextPartBuilder().apply(block).build()
+    public fun textPart(block: TextPartBuilder.() -> Unit): TextPart =
+        TextPartBuilder().apply(block).build()
 
     public fun textPart(block: Consumer<TextPartBuilder>): TextPart {
         val builder = TextPartBuilder()
@@ -58,7 +59,8 @@ public class MessageBuilder {
 
     public fun text(block: () -> String): TextPart = TextPartBuilder().text(block.invoke()).build()
 
-    public fun filePart(block: FilePartBuilder.() -> Unit): FilePart = FilePartBuilder().apply(block).build()
+    public fun filePart(block: FilePartBuilder.() -> Unit): FilePart =
+        FilePartBuilder().apply(block).build()
 
     public fun filePart(block: Consumer<FilePartBuilder>): FilePart {
         val builder = FilePartBuilder()
@@ -71,7 +73,8 @@ public class MessageBuilder {
             this.file(block)
         }
 
-    public fun dataPart(block: DataPartBuilder.() -> Unit): DataPart = DataPartBuilder().apply(block).build()
+    public fun dataPart(block: DataPartBuilder.() -> Unit): DataPart =
+        DataPartBuilder().apply(block).build()
 
     public fun dataPart(block: Consumer<DataPartBuilder>): DataPart {
         val builder = DataPartBuilder()
@@ -108,7 +111,8 @@ public class MessageBuilder {
  * @param init The lambda to configure the message.
  * @return A new [Message] instance.
  */
-public inline fun message(init: MessageBuilder.() -> Unit): Message = MessageBuilder().apply(init).build()
+public inline fun message(init: MessageBuilder.() -> Unit): Message =
+    MessageBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [Message].
@@ -128,7 +132,8 @@ public fun message(init: Consumer<MessageBuilder>): Message {
  * @param init The lambda to configure the message.
  * @return A new [Message] instance.
  */
-public fun Message.Companion.create(init: MessageBuilder.() -> Unit): Message = MessageBuilder().apply(init).build()
+public fun Message.Companion.create(init: MessageBuilder.() -> Unit): Message =
+    MessageBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [Message.Companion].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/MethodNotFoundErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/MethodNotFoundErrorBuilder.kt
@@ -12,7 +12,8 @@ import java.util.function.Consumer
  * }
  * ```
  */
-public class MethodNotFoundErrorBuilder : JSONRPCErrorBuilder<MethodNotFoundError, MethodNotFoundErrorBuilder>() {
+public class MethodNotFoundErrorBuilder :
+    JSONRPCErrorBuilder<MethodNotFoundError, MethodNotFoundErrorBuilder>() {
     /**
      * Builds a [MethodNotFoundError] instance with the configured parameters.
      *
@@ -30,8 +31,9 @@ public class MethodNotFoundErrorBuilder : JSONRPCErrorBuilder<MethodNotFoundErro
  * @param init The lambda to configure the method not found error.
  * @return A new [MethodNotFoundError] instance.
  */
-public inline fun methodNotFoundError(init: MethodNotFoundErrorBuilder.() -> Unit): MethodNotFoundError =
-    MethodNotFoundErrorBuilder().apply(init).build()
+public inline fun methodNotFoundError(
+    init: MethodNotFoundErrorBuilder.() -> Unit,
+): MethodNotFoundError = MethodNotFoundErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [MethodNotFoundError].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
@@ -90,8 +90,9 @@ public class PushNotificationConfigBuilder {
  * @param init The lambda to configure the push notification config.
  * @return A new [PushNotificationConfig] instance.
  */
-public inline fun pushNotificationConfig(init: PushNotificationConfigBuilder.() -> Unit): PushNotificationConfig =
-    PushNotificationConfigBuilder().apply(init).build()
+public inline fun pushNotificationConfig(
+    init: PushNotificationConfigBuilder.() -> Unit,
+): PushNotificationConfig = PushNotificationConfigBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [PushNotificationConfig].
@@ -99,7 +100,9 @@ public inline fun pushNotificationConfig(init: PushNotificationConfigBuilder.() 
  * @param init The consumer to configure the push notification config.
  * @return A new [PushNotificationConfig] instance.
  */
-public fun pushNotificationConfig(init: Consumer<PushNotificationConfigBuilder>): PushNotificationConfig {
+public fun pushNotificationConfig(
+    init: Consumer<PushNotificationConfigBuilder>,
+): PushNotificationConfig {
     val builder = PushNotificationConfigBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilder.kt
@@ -132,15 +132,3 @@ public fun PushNotificationConfig.Companion.create(
     block.accept(builder)
     return builder.build()
 }
-
-/**
- * Creates a new instance of a PushNotificationConfig using the provided configuration block.
- * This is a convenience function for the companion object.
- *
- * @param block A configuration block for building a PushNotificationConfig instance
- * using the PushNotificationConfigBuilder.
- * @return A newly created PushNotificationConfig instance.
- */
-public fun PushNotificationConfig.Companion.build(
-    block: PushNotificationConfigBuilder.() -> Unit,
-): PushNotificationConfig = PushNotificationConfigBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationNotSupportedErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationNotSupportedErrorBuilder.kt
@@ -36,7 +36,8 @@ public class PushNotificationNotSupportedErrorBuilder :
  */
 public inline fun pushNotificationNotSupportedError(
     init: PushNotificationNotSupportedErrorBuilder.() -> Unit,
-): PushNotificationNotSupportedError = PushNotificationNotSupportedErrorBuilder().apply(init).build()
+): PushNotificationNotSupportedError =
+    PushNotificationNotSupportedErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [PushNotificationNotSupportedError].
@@ -60,7 +61,8 @@ public fun pushNotificationNotSupportedError(
  */
 public fun PushNotificationNotSupportedError.Companion.create(
     init: PushNotificationNotSupportedErrorBuilder.() -> Unit,
-): PushNotificationNotSupportedError = PushNotificationNotSupportedErrorBuilder().apply(init).build()
+): PushNotificationNotSupportedError =
+    PushNotificationNotSupportedErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [PushNotificationNotSupportedError.Companion].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendMessageRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendMessageRequest.kt
@@ -24,13 +24,13 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class SendMessageRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    val id: RequestId? = null,
+    override val id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "message/send",
+    override val method: String = "message/send",
     @SerialName("params")
     val params: MessageSendParams,
 ) : A2ARequest {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendMessageRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendMessageRequestBuilder.kt
@@ -93,8 +93,9 @@ public class SendMessageRequestBuilder {
  * @param init The lambda to configure the send message request.
  * @return A new [SendMessageRequest] instance.
  */
-public inline fun sendMessageRequest(init: SendMessageRequestBuilder.() -> Unit): SendMessageRequest =
-    SendMessageRequestBuilder().apply(init).build()
+public inline fun sendMessageRequest(
+    init: SendMessageRequestBuilder.() -> Unit,
+): SendMessageRequest = SendMessageRequestBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [SendMessageRequest].
@@ -114,8 +115,9 @@ public fun sendMessageRequest(init: Consumer<SendMessageRequestBuilder>): SendMe
  * @param block A configuration block for building a SendMessageRequest instance using the SendMessageRequestBuilder.
  * @return A newly created SendMessageRequest instance.
  */
-public fun SendMessageRequest.Companion.create(block: SendMessageRequestBuilder.() -> Unit): SendMessageRequest =
-    SendMessageRequestBuilder().apply(block).build()
+public fun SendMessageRequest.Companion.create(
+    block: SendMessageRequestBuilder.() -> Unit,
+): SendMessageRequest = SendMessageRequestBuilder().apply(block).build()
 
 /**
  * Creates a new instance of a SendMessageRequest using the provided Java-friendly Consumer.
@@ -123,7 +125,9 @@ public fun SendMessageRequest.Companion.create(block: SendMessageRequestBuilder.
  * @param block A consumer for building a SendMessageRequest instance using the SendMessageRequestBuilder.
  * @return A newly created SendMessageRequest instance.
  */
-public fun SendMessageRequest.Companion.create(block: Consumer<SendMessageRequestBuilder>): SendMessageRequest {
+public fun SendMessageRequest.Companion.create(
+    block: Consumer<SendMessageRequestBuilder>,
+): SendMessageRequest {
     val builder = SendMessageRequestBuilder()
     block.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendMessageResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendMessageResponseBuilder.kt
@@ -124,8 +124,9 @@ public class SendMessageResponseBuilder {
  * @param init The lambda to configure the send message response.
  * @return A new [SendMessageResponse] instance.
  */
-public inline fun sendMessageResponse(init: SendMessageResponseBuilder.() -> Unit): SendMessageResponse =
-    SendMessageResponseBuilder().apply(init).build()
+public inline fun sendMessageResponse(
+    init: SendMessageResponseBuilder.() -> Unit,
+): SendMessageResponse = SendMessageResponseBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [SendMessageResponse].
@@ -145,8 +146,9 @@ public fun sendMessageResponse(init: Consumer<SendMessageResponseBuilder>): Send
  * @param block A configuration block for building a SendMessageResponse instance using the SendMessageResponseBuilder.
  * @return A newly created SendMessageResponse instance.
  */
-public fun SendMessageResponse.Companion.create(block: SendMessageResponseBuilder.() -> Unit): SendMessageResponse =
-    SendMessageResponseBuilder().apply(block).build()
+public fun SendMessageResponse.Companion.create(
+    block: SendMessageResponseBuilder.() -> Unit,
+): SendMessageResponse = SendMessageResponseBuilder().apply(block).build()
 
 /**
  * Creates a new instance of a SendMessageResponse using the provided Java-friendly Consumer.
@@ -154,7 +156,9 @@ public fun SendMessageResponse.Companion.create(block: SendMessageResponseBuilde
  * @param block A consumer for building a SendMessageResponse instance using the SendMessageResponseBuilder.
  * @return A newly created SendMessageResponse instance.
  */
-public fun SendMessageResponse.Companion.create(block: Consumer<SendMessageResponseBuilder>): SendMessageResponse {
+public fun SendMessageResponse.Companion.create(
+    block: Consumer<SendMessageResponseBuilder>,
+): SendMessageResponse {
     val builder = SendMessageResponseBuilder()
     block.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendStreamingMessageRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendStreamingMessageRequest.kt
@@ -24,13 +24,13 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class SendStreamingMessageRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    var id: RequestId? = null,
+    override var id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "message/stream",
+    override val method: String = "message/stream",
     @SerialName("params")
     val params: MessageSendParams,
 ) : A2ARequest {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendStreamingMessageRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendStreamingMessageRequestBuilder.kt
@@ -53,7 +53,9 @@ public class SendStreamingMessageRequestBuilder {
      * @param init The lambda to configure the message send params.
      * @return This builder instance for method chaining.
      */
-    public fun params(init: MessageSendParamsBuilder.() -> Unit): SendStreamingMessageRequestBuilder =
+    public fun params(
+        init: MessageSendParamsBuilder.() -> Unit,
+    ): SendStreamingMessageRequestBuilder =
         apply {
             this.params = MessageSendParams.build(init)
         }
@@ -64,7 +66,9 @@ public class SendStreamingMessageRequestBuilder {
      * @param init The consumer to configure the message send params.
      * @return This builder instance for method chaining.
      */
-    public fun params(init: Consumer<MessageSendParamsBuilder>): SendStreamingMessageRequestBuilder =
+    public fun params(
+        init: Consumer<MessageSendParamsBuilder>,
+    ): SendStreamingMessageRequestBuilder =
         apply {
             val builder = MessageSendParamsBuilder()
             init.accept(builder)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendStreamingMessageResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SendStreamingMessageResponseBuilder.kt
@@ -66,7 +66,9 @@ public class SendStreamingMessageResponseBuilder {
      * @param init The lambda to configure the task status update event.
      * @return This builder instance for method chaining.
      */
-    public fun taskStatusUpdate(init: TaskStatusUpdateEventBuilder.() -> Unit): SendStreamingMessageResponseBuilder =
+    public fun taskStatusUpdate(
+        init: TaskStatusUpdateEventBuilder.() -> Unit,
+    ): SendStreamingMessageResponseBuilder =
         apply {
             this.result = TaskStatusUpdateEvent.create(init)
         }
@@ -77,7 +79,9 @@ public class SendStreamingMessageResponseBuilder {
      * @param init The consumer to configure the task status update event.
      * @return This builder instance for method chaining.
      */
-    public fun taskStatusUpdate(init: Consumer<TaskStatusUpdateEventBuilder>): SendStreamingMessageResponseBuilder =
+    public fun taskStatusUpdate(
+        init: Consumer<TaskStatusUpdateEventBuilder>,
+    ): SendStreamingMessageResponseBuilder =
         apply {
             val builder = TaskStatusUpdateEventBuilder()
             init.accept(builder)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationRequest.kt
@@ -20,13 +20,13 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class SetTaskPushNotificationRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    var id: RequestId? = null,
+    override var id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "tasks/pushNotificationConfig/set",
+    override val method: String = "tasks/pushNotificationConfig/set",
     @SerialName("params")
     val params: TaskPushNotificationConfig,
 ) : A2ARequest {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationRequestBuilder.kt
@@ -40,7 +40,9 @@ public class SetTaskPushNotificationRequestBuilder {
      * @param init The lambda to configure the task push notification config.
      * @return This builder instance for method chaining.
      */
-    public fun params(init: TaskPushNotificationConfigBuilder.() -> Unit): SetTaskPushNotificationRequestBuilder =
+    public fun params(
+        init: TaskPushNotificationConfigBuilder.() -> Unit,
+    ): SetTaskPushNotificationRequestBuilder =
         apply {
             params = TaskPushNotificationConfig.create(init)
         }
@@ -51,7 +53,9 @@ public class SetTaskPushNotificationRequestBuilder {
      * @param init The consumer to configure the task push notification config.
      * @return This builder instance for method chaining.
      */
-    public fun params(init: Consumer<TaskPushNotificationConfigBuilder>): SetTaskPushNotificationRequestBuilder =
+    public fun params(
+        init: Consumer<TaskPushNotificationConfigBuilder>,
+    ): SetTaskPushNotificationRequestBuilder =
         apply {
             val builder = TaskPushNotificationConfigBuilder()
             init.accept(builder)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationResponseBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/SetTaskPushNotificationResponseBuilder.kt
@@ -52,7 +52,9 @@ public class SetTaskPushNotificationResponseBuilder {
      * @param init The lambda to configure the task push notification config.
      * @return This builder instance for method chaining.
      */
-    public fun result(init: TaskPushNotificationConfigBuilder.() -> Unit): SetTaskPushNotificationResponseBuilder =
+    public fun result(
+        init: TaskPushNotificationConfigBuilder.() -> Unit,
+    ): SetTaskPushNotificationResponseBuilder =
         apply {
             result = TaskPushNotificationConfig.create(init)
         }
@@ -63,7 +65,9 @@ public class SetTaskPushNotificationResponseBuilder {
      * @param init The consumer to configure the task push notification config.
      * @return This builder instance for method chaining.
      */
-    public fun result(init: Consumer<TaskPushNotificationConfigBuilder>): SetTaskPushNotificationResponseBuilder =
+    public fun result(
+        init: Consumer<TaskPushNotificationConfigBuilder>,
+    ): SetTaskPushNotificationResponseBuilder =
         apply {
             val builder = TaskPushNotificationConfigBuilder()
             init.accept(builder)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEventBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskArtifactUpdateEventBuilder.kt
@@ -117,8 +117,9 @@ public fun TaskArtifactUpdateEvent.Companion.create(
  * @param init The lambda to configure the TaskArtifactUpdateEvent.
  * @return A new TaskArtifactUpdateEvent instance.
  */
-public inline fun taskArtifactUpdateEvent(init: TaskArtifactUpdateEventBuilder.() -> Unit): TaskArtifactUpdateEvent =
-    TaskArtifactUpdateEventBuilder().apply(init).build()
+public inline fun taskArtifactUpdateEvent(
+    init: TaskArtifactUpdateEventBuilder.() -> Unit,
+): TaskArtifactUpdateEvent = TaskArtifactUpdateEventBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [TaskArtifactUpdateEvent].
@@ -126,7 +127,9 @@ public inline fun taskArtifactUpdateEvent(init: TaskArtifactUpdateEventBuilder.(
  * @param init The consumer to configure the TaskArtifactUpdateEvent.
  * @return A new TaskArtifactUpdateEvent instance.
  */
-public fun taskArtifactUpdateEvent(init: Consumer<TaskArtifactUpdateEventBuilder>): TaskArtifactUpdateEvent {
+public fun taskArtifactUpdateEvent(
+    init: Consumer<TaskArtifactUpdateEventBuilder>,
+): TaskArtifactUpdateEvent {
     val builder = TaskArtifactUpdateEventBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskBuilder.kt
@@ -117,7 +117,8 @@ public class TaskBuilder {
      * @param block The lambda to configure the artifact.
      * @return The created artifact.
      */
-    public fun artifact(block: ArtifactBuilder.() -> Unit): Artifact = ArtifactBuilder().apply(block).build()
+    public fun artifact(block: ArtifactBuilder.() -> Unit): Artifact =
+        ArtifactBuilder().apply(block).build()
 
     /**
      * Creates an artifact using the provided Java-friendly Consumer and adds it to the task.
@@ -190,7 +191,8 @@ public fun task(init: Consumer<TaskBuilder>): Task {
  * @param block A configuration block for building a Task instance using the TaskBuilder.
  * @return A newly created Task instance.
  */
-public fun Task.Companion.create(block: TaskBuilder.() -> Unit): Task = TaskBuilder().apply(block).build()
+public fun Task.Companion.create(block: TaskBuilder.() -> Unit): Task =
+    TaskBuilder().apply(block).build()
 
 /**
  * Creates a new instance of a Task using the provided Java-friendly Consumer.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotCancelableErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotCancelableErrorBuilder.kt
@@ -31,8 +31,9 @@ public class TaskNotCancelableErrorBuilder :
  * @param init The lambda to configure the task not cancelable error.
  * @return A new [TaskNotCancelableError] instance.
  */
-public inline fun taskNotCancelableError(init: TaskNotCancelableErrorBuilder.() -> Unit): TaskNotCancelableError =
-    TaskNotCancelableErrorBuilder().apply(init).build()
+public inline fun taskNotCancelableError(
+    init: TaskNotCancelableErrorBuilder.() -> Unit,
+): TaskNotCancelableError = TaskNotCancelableErrorBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [TaskNotCancelableError].
@@ -40,7 +41,9 @@ public inline fun taskNotCancelableError(init: TaskNotCancelableErrorBuilder.() 
  * @param init The consumer to configure the task not cancelable error.
  * @return A new [TaskNotCancelableError] instance.
  */
-public fun taskNotCancelableError(init: Consumer<TaskNotCancelableErrorBuilder>): TaskNotCancelableError {
+public fun taskNotCancelableError(
+    init: Consumer<TaskNotCancelableErrorBuilder>,
+): TaskNotCancelableError {
     val builder = TaskNotCancelableErrorBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotFoundErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskNotFoundErrorBuilder.kt
@@ -12,7 +12,8 @@ import java.util.function.Consumer
  * }
  * ```
  */
-public class TaskNotFoundErrorBuilder : JSONRPCErrorBuilder<TaskNotFoundError, TaskNotFoundErrorBuilder>() {
+public class TaskNotFoundErrorBuilder :
+    JSONRPCErrorBuilder<TaskNotFoundError, TaskNotFoundErrorBuilder>() {
     /**
      * Builds a [TaskNotFoundError] instance with the configured parameters.
      *

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilder.kt
@@ -128,15 +128,3 @@ public fun TaskPushNotificationConfig.Companion.create(
     block.accept(builder)
     return builder.build()
 }
-
-/**
- * Creates a new instance of a TaskPushNotificationConfig using the provided configuration block.
- * This is a convenience function for the companion object.
- *
- * @param block A configuration block for building a TaskPushNotificationConfig instance
- * using the TaskPushNotificationConfigBuilder.
- * @return A newly created TaskPushNotificationConfig instance.
- */
-public fun TaskPushNotificationConfig.Companion.build(
-    block: TaskPushNotificationConfigBuilder.() -> Unit,
-): TaskPushNotificationConfig = TaskPushNotificationConfigBuilder().apply(block).build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilder.kt
@@ -95,7 +95,9 @@ public inline fun taskPushNotificationConfig(
  * @param init The consumer to configure the task push notification config.
  * @return A new [TaskPushNotificationConfig] instance.
  */
-public fun taskPushNotificationConfig(init: Consumer<TaskPushNotificationConfigBuilder>): TaskPushNotificationConfig {
+public fun taskPushNotificationConfig(
+    init: Consumer<TaskPushNotificationConfigBuilder>,
+): TaskPushNotificationConfig {
     val builder = TaskPushNotificationConfigBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskQueryParamsBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskQueryParamsBuilder.kt
@@ -93,8 +93,9 @@ public fun taskQueryParams(init: Consumer<TaskQueryParamsBuilder>): TaskQueryPar
  * @param init The lambda to configure the task query params.
  * @return A new [TaskQueryParams] instance.
  */
-public fun TaskQueryParams.Companion.create(init: TaskQueryParamsBuilder.() -> Unit): TaskQueryParams =
-    TaskQueryParamsBuilder().apply(init).build()
+public fun TaskQueryParams.Companion.create(
+    init: TaskQueryParamsBuilder.() -> Unit,
+): TaskQueryParams = TaskQueryParamsBuilder().apply(init).build()
 
 /**
  * Java-friendly DSL extension for [TaskQueryParams.Companion].
@@ -102,7 +103,9 @@ public fun TaskQueryParams.Companion.create(init: TaskQueryParamsBuilder.() -> U
  * @param init The consumer to configure the task query params.
  * @return A new [TaskQueryParams] instance.
  */
-public fun TaskQueryParams.Companion.create(init: Consumer<TaskQueryParamsBuilder>): TaskQueryParams {
+public fun TaskQueryParams.Companion.create(
+    init: Consumer<TaskQueryParamsBuilder>,
+): TaskQueryParams {
     val builder = TaskQueryParamsBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskResubscriptionRequest.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskResubscriptionRequest.kt
@@ -20,13 +20,13 @@ import me.kpavlov.aimocks.a2a.model.serializers.RequestIdSerializer
 public data class TaskResubscriptionRequest(
     @SerialName("jsonrpc")
     @EncodeDefault
-    val jsonrpc: String = "2.0",
+    override val jsonrpc: String = "2.0",
     @SerialName("id")
     @Serializable(with = RequestIdSerializer::class)
-    var id: RequestId? = null,
+    override var id: RequestId? = null,
     @SerialName("method")
     @EncodeDefault
-    val method: String = "tasks/resubscribe",
+    override val method: String = "tasks/resubscribe",
     @SerialName("params")
     val params: TaskQueryParams,
 ) : A2ARequest {

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskResubscriptionRequestBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskResubscriptionRequestBuilder.kt
@@ -84,7 +84,9 @@ public inline fun taskResubscriptionRequest(
  * @param init The consumer to configure the task resubscription request.
  * @return A new [TaskResubscriptionRequest] instance.
  */
-public fun taskResubscriptionRequest(init: Consumer<TaskResubscriptionRequestBuilder>): TaskResubscriptionRequest {
+public fun taskResubscriptionRequest(
+    init: Consumer<TaskResubscriptionRequestBuilder>,
+): TaskResubscriptionRequest {
     val builder = TaskResubscriptionRequestBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParamsBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParamsBuilder.kt
@@ -85,7 +85,9 @@ public class TaskSendParamsBuilder {
      * @param init The lambda to configure the push notification config.
      * @return The updated [TaskSendParamsBuilder] instance for method chaining.
      */
-    public fun pushNotification(init: PushNotificationConfigBuilder.() -> Unit): TaskSendParamsBuilder =
+    public fun pushNotification(
+        init: PushNotificationConfigBuilder.() -> Unit,
+    ): TaskSendParamsBuilder =
         apply {
             this.pushNotification = PushNotificationConfig.build(init)
         }
@@ -96,7 +98,9 @@ public class TaskSendParamsBuilder {
      * @param init The consumer to configure the push notification config.
      * @return The updated [TaskSendParamsBuilder] instance for method chaining.
      */
-    public fun pushNotification(init: Consumer<PushNotificationConfigBuilder>): TaskSendParamsBuilder =
+    public fun pushNotification(
+        init: Consumer<PushNotificationConfigBuilder>,
+    ): TaskSendParamsBuilder =
         apply {
             val builder = PushNotificationConfigBuilder()
             init.accept(builder)
@@ -140,8 +144,9 @@ public class TaskSendParamsBuilder {
  * @param block A configuration block for building a TaskSendParams instance using the TaskSendParamsBuilder.
  * @return A newly created TaskSendParams instance.
  */
-public fun TaskSendParams.Companion.create(block: TaskSendParamsBuilder.() -> Unit): TaskSendParams =
-    TaskSendParamsBuilder().apply(block).build()
+public fun TaskSendParams.Companion.create(
+    block: TaskSendParamsBuilder.() -> Unit,
+): TaskSendParams = TaskSendParamsBuilder().apply(block).build()
 
 /**
  * Creates a new instance of a TaskSendParams using the provided Java-friendly Consumer.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParamsBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskSendParamsBuilder.kt
@@ -89,7 +89,7 @@ public class TaskSendParamsBuilder {
         init: PushNotificationConfigBuilder.() -> Unit,
     ): TaskSendParamsBuilder =
         apply {
-            this.pushNotification = PushNotificationConfig.build(init)
+            this.pushNotification = PushNotificationConfig.create(init)
         }
 
     /**

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatus.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatus.kt
@@ -54,6 +54,7 @@ public data class TaskStatus
              * @param init The lambda to configure the task status.
              * @return A new TaskStatus instance.
              */
-            public fun build(init: TaskStatusBuilder.() -> Unit): TaskStatus = TaskStatusBuilder().apply(init).build()
+            public fun build(init: TaskStatusBuilder.() -> Unit): TaskStatus =
+                TaskStatusBuilder().apply(init).build()
         }
     }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusBuilder.kt
@@ -94,7 +94,8 @@ public class TaskStatusBuilder {
  * @param init The lambda to configure the task status.
  * @return A new [TaskStatus] instance.
  */
-public inline fun taskStatus(init: TaskStatusBuilder.() -> Unit): TaskStatus = TaskStatusBuilder().apply(init).build()
+public inline fun taskStatus(init: TaskStatusBuilder.() -> Unit): TaskStatus =
+    TaskStatusBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [TaskStatus].

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusUpdateEventBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TaskStatusUpdateEventBuilder.kt
@@ -101,13 +101,16 @@ public class TaskStatusUpdateEventBuilder {
 /**
  * Top-level DSL function for creating [TaskStatusUpdateEvent].
  */
-public inline fun taskStatusUpdateEvent(init: TaskStatusUpdateEventBuilder.() -> Unit): TaskStatusUpdateEvent =
-    TaskStatusUpdateEventBuilder().apply(init).build()
+public inline fun taskStatusUpdateEvent(
+    init: TaskStatusUpdateEventBuilder.() -> Unit,
+): TaskStatusUpdateEvent = TaskStatusUpdateEventBuilder().apply(init).build()
 
 /**
  * Java-friendly top-level DSL function for creating [TaskStatusUpdateEvent].
  */
-public fun taskStatusUpdateEvent(init: Consumer<TaskStatusUpdateEventBuilder>): TaskStatusUpdateEvent {
+public fun taskStatusUpdateEvent(
+    init: Consumer<TaskStatusUpdateEventBuilder>,
+): TaskStatusUpdateEvent {
     val builder = TaskStatusUpdateEventBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TextPartBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/TextPartBuilder.kt
@@ -73,7 +73,8 @@ public class TextPartBuilder {
  * @param init The lambda to configure the text part
  * @return A new TextPart instance
  */
-public inline fun textPart(init: TextPartBuilder.() -> Unit): TextPart = TextPartBuilder().apply(init).build()
+public inline fun textPart(init: TextPartBuilder.() -> Unit): TextPart =
+    TextPartBuilder().apply(init).build()
 
 /**
  * Creates a new TextPart using the Java-friendly Consumer.
@@ -93,7 +94,8 @@ public fun textPart(init: Consumer<TextPartBuilder>): TextPart {
  * @param init The lambda to configure the text part
  * @return A new TextPart instance
  */
-public fun TextPart.Companion.create(init: TextPartBuilder.() -> Unit): TextPart = TextPartBuilder().apply(init).build()
+public fun TextPart.Companion.create(init: TextPartBuilder.() -> Unit): TextPart =
+    TextPartBuilder().apply(init).build()
 
 /**
  * Creates a new TextPart using the Java-friendly Consumer.

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/UnsupportedOperationError.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/UnsupportedOperationError.kt
@@ -18,7 +18,8 @@ public class UnsupportedOperationError : JSONRPCError {
     @JvmOverloads
     public constructor(data: Data? = null) : super(-32004, "This operation is not supported", null)
 
-    public fun copy(data: Data? = this.data): UnsupportedOperationError = UnsupportedOperationError(data)
+    public fun copy(data: Data? = this.data): UnsupportedOperationError =
+        UnsupportedOperationError(data)
 
     private companion object
 }

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/UnsupportedOperationErrorBuilder.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/UnsupportedOperationErrorBuilder.kt
@@ -41,7 +41,9 @@ public inline fun unsupportedOperationError(
  * @param init The consumer to configure the unsupported operation error.
  * @return A new [UnsupportedOperationError] instance.
  */
-public fun unsupportedOperationError(init: Consumer<UnsupportedOperationErrorBuilder>): UnsupportedOperationError {
+public fun unsupportedOperationError(
+    init: Consumer<UnsupportedOperationErrorBuilder>,
+): UnsupportedOperationError {
     val builder = UnsupportedOperationErrorBuilder()
     init.accept(builder)
     return builder.build()

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/PartSerializer.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/PartSerializer.kt
@@ -52,10 +52,8 @@ public class PartSerializer : KSerializer<Part> {
             jsonElement["kind"]
                 ?: throw SerializationException("Missing 'kind' discriminator in Part JSON")
 
-        val kind = kindElement.jsonPrimitive.content
-
         // Determine which subclass to use based on the "kind" value
-        return when (kind) {
+        return when (val kind = kindElement.jsonPrimitive.content) {
             "text" -> jsonDecoder.json.decodeFromJsonElement(textPartSerializer, jsonElement)
             "file" -> jsonDecoder.json.decodeFromJsonElement(filePartSerializer, jsonElement)
             "data" -> jsonDecoder.json.decodeFromJsonElement(dataPartSerializer, jsonElement)

--- a/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/RequestIdSerializer.kt
+++ b/ai-mocks-a2a-models/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/model/serializers/RequestIdSerializer.kt
@@ -21,11 +21,9 @@ public class RequestIdSerializer : KSerializer<RequestId?> {
     override fun deserialize(decoder: Decoder): RequestId? {
         val jsonDecoder =
             decoder as? JsonDecoder ?: throw SerializationException("Expected JSON decoder")
-        val element = jsonDecoder.decodeJsonElement()
-
-        return when {
-            element is JsonNull -> null
-            element is JsonPrimitive -> {
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonNull -> null
+            is JsonPrimitive -> {
                 // Try to convert to Int first, if not possible, use as String
                 element.intOrNull ?: element.content
             }

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigParamsBuilderTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigParamsBuilderTest.kt
@@ -1,0 +1,109 @@
+package me.kpavlov.aimocks.a2a.model
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+internal class DeleteTaskPushNotificationConfigParamsBuilderTest {
+    @Test
+    fun `should build DeleteTaskPushNotificationConfigParams with required parameters`() {
+        // when
+        val builder = DeleteTaskPushNotificationConfigParamsBuilder()
+        builder.id = "task-123"
+        val params = builder.build()
+
+        // then
+        params.id shouldBe "task-123"
+        params.metadata shouldBe null
+    }
+
+    @Test
+    fun `should build DeleteTaskPushNotificationConfigParams with all parameters`() {
+        // given
+        val metadata = mapOf<String, JsonElement>(
+            "key1" to JsonPrimitive("value1"),
+            "key2" to JsonPrimitive(42),
+        )
+
+        // when
+        val builder = DeleteTaskPushNotificationConfigParamsBuilder()
+        builder.id = "task-123"
+        builder.metadata = metadata
+        val params = builder.build()
+
+        // then
+        params.id shouldBe "task-123"
+        params.metadata shouldBe metadata
+        params.metadata?.get("key1") shouldBe JsonPrimitive("value1")
+        params.metadata?.get("key2") shouldBe JsonPrimitive(42)
+    }
+
+    @Test
+    fun `should fail when id is not provided`() {
+        // when/then
+        assertFailsWith<IllegalArgumentException> {
+            DeleteTaskPushNotificationConfigParamsBuilder().build()
+        }
+    }
+
+    @Test
+    fun `should build using top-level DSL function`() {
+        // given
+        val metadata = mapOf<String, JsonElement>(
+            "key1" to JsonPrimitive("value1"),
+            "key2" to JsonPrimitive(42),
+        )
+
+        // when
+        val params =
+            deleteTaskPushNotificationConfigParams {
+                id = "task-123"
+                this.metadata = metadata
+            }
+
+        // then
+        params.id shouldBe "task-123"
+        params.metadata shouldBe metadata
+    }
+
+    @Test
+    fun `should build with method chaining`() {
+        // given
+        val metadata = mapOf<String, JsonElement>(
+            "key1" to JsonPrimitive("value1"),
+        )
+
+        // when
+        val params =
+            DeleteTaskPushNotificationConfigParamsBuilder()
+                .id("task-456")
+                .metadata(metadata)
+                .build()
+
+        // then
+        params.id shouldBe "task-456"
+        params.metadata shouldBe metadata
+    }
+
+    @Test
+    fun `should build using Java-friendly Consumer factory method`() {
+        // given
+        val metadata = mapOf<String, JsonElement>(
+            "key1" to JsonPrimitive("value1"),
+            "key2" to JsonPrimitive(42),
+        )
+
+        // when
+        val params =
+            deleteTaskPushNotificationConfigParams { builder ->
+                builder.id = "task-789"
+                builder.metadata = metadata
+            }
+
+        // then
+        params.id shouldBe "task-789"
+        params.metadata shouldBe metadata
+    }
+}

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigRequestBuilderTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigRequestBuilderTest.kt
@@ -1,0 +1,110 @@
+package me.kpavlov.aimocks.a2a.model
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+
+internal class DeleteTaskPushNotificationConfigRequestBuilderTest {
+    @Test
+    fun `should build using top-level DSL function`() {
+        // given
+        val metadata =
+            mapOf<String, JsonElement>(
+                "key1" to JsonPrimitive("value1"),
+            )
+
+        // when
+        val request =
+            deleteTaskPushNotificationConfigRequest {
+                id = "request-123"
+                params {
+                    id = "task-123"
+                    this.metadata = metadata
+                }
+            }
+
+        // then
+        request.id shouldBe "request-123"
+        request.params shouldBe
+            DeleteTaskPushNotificationConfigParams(
+                id = "task-123",
+                metadata = metadata,
+            )
+        request.jsonrpc shouldBe "2.0"
+        request.method shouldBe "tasks/pushNotificationConfig/delete"
+    }
+
+    @Test
+    fun `should build using companion object create function`() {
+        // when
+        val request =
+            DeleteTaskPushNotificationConfigRequest.create {
+                id = "request-123"
+                params {
+                    id = "task-123"
+                }
+            }
+
+        // then
+        request.id shouldBe "request-123"
+        request.params shouldBe
+            DeleteTaskPushNotificationConfigParams(
+                id = "task-123",
+                metadata = null,
+            )
+        request.jsonrpc shouldBe "2.0"
+        request.method shouldBe "tasks/pushNotificationConfig/delete"
+    }
+
+    @Test
+    fun `should build using Consumer factory method`() {
+        // given
+        val metadata =
+            mapOf<String, JsonElement>(
+                "key1" to JsonPrimitive("value1"),
+            )
+
+        // when
+        val request =
+            deleteTaskPushNotificationConfigRequest { builder ->
+                builder.id = "request-789"
+                builder.params { paramsBuilder ->
+                    paramsBuilder.id = "task-789"
+                    paramsBuilder.metadata = metadata
+                }
+            }
+
+        // then
+        request.id shouldBe "request-789"
+        request.params shouldBe
+            DeleteTaskPushNotificationConfigParams(
+                id = "task-789",
+                metadata = metadata,
+            )
+        request.jsonrpc shouldBe "2.0"
+        request.method shouldBe "tasks/pushNotificationConfig/delete"
+    }
+
+    @Test
+    fun `should build using Consumer companion create method`() {
+        // when
+        val request =
+            DeleteTaskPushNotificationConfigRequest.create { builder ->
+                builder.id = "request-999"
+                builder.params { paramsBuilder ->
+                    paramsBuilder.id = "task-999"
+                }
+            }
+
+        // then
+        request.id shouldBe "request-999"
+        request.params shouldBe
+            DeleteTaskPushNotificationConfigParams(
+                id = "task-999",
+                metadata = null,
+            )
+        request.jsonrpc shouldBe "2.0"
+        request.method shouldBe "tasks/pushNotificationConfig/delete"
+    }
+}

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/DeleteTaskPushNotificationConfigTest.kt
@@ -1,0 +1,138 @@
+package me.kpavlov.aimocks.a2a.model
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+/**
+ * https://a2a-protocol.org/latest/specification/#78-taskspushnotificationconfigdelete
+ */
+internal class DeleteTaskPushNotificationConfigTest : AbstractSerializationTest() {
+    @Test
+    fun `Deserialize and Serialize DeleteTaskPushNotificationConfigRequest`() {
+        // language=json
+        val payload =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "method": "tasks/pushNotificationConfig/delete",
+              "params": {
+                "id": "task_12345"
+              }
+            }
+            """.trimIndent()
+
+        val model = deserializeAndSerialize<DeleteTaskPushNotificationConfigRequest>(payload)
+        model.id shouldBe 1
+        model.method shouldBe "tasks/pushNotificationConfig/delete"
+        model.params?.id shouldBe "task_12345"
+        model.params?.metadata shouldBe null
+    }
+
+    @Test
+    fun `Deserialize and Serialize DeleteTaskPushNotificationConfigRequest with metadata`() {
+        // language=json
+        val payload =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": "request-123",
+              "method": "tasks/pushNotificationConfig/delete",
+              "params": {
+                "id": "task_67890",
+                "metadata": {
+                  "source": "client",
+                  "version": 1
+                }
+              }
+            }
+            """.trimIndent()
+
+        val model = deserializeAndSerialize<DeleteTaskPushNotificationConfigRequest>(payload)
+        model.id shouldBe "request-123"
+        model.method shouldBe "tasks/pushNotificationConfig/delete"
+        model.params?.id shouldBe "task_67890"
+        model.params?.metadata?.size shouldBe 2
+        model.params?.metadata?.containsKey("source") shouldBe true
+        model.params?.metadata?.containsKey("version") shouldBe true
+    }
+
+    @Test
+    fun `Deserialize and Serialize DeleteTaskPushNotificationConfigRequest without params`() {
+        // language=json
+        val payload =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "method": "tasks/pushNotificationConfig/delete"
+            }
+            """.trimIndent()
+
+        val model = deserializeAndSerialize<DeleteTaskPushNotificationConfigRequest>(payload)
+        model.id shouldBe 1
+        model.method shouldBe "tasks/pushNotificationConfig/delete"
+        model.params shouldBe null
+    }
+
+    @Test
+    fun `Deserialize and Serialize DeleteTaskPushNotificationConfigResponse with success`() {
+        // language=json
+        val payload =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1
+            }
+            """.trimIndent()
+
+        val model = deserializeAndSerialize<DeleteTaskPushNotificationConfigResponse>(payload)
+        model.id shouldBe 1
+        model.result shouldBe null
+        model.error shouldBe null
+    }
+
+    @Test
+    fun `Deserialize and Serialize DeleteTaskPushNotificationConfigResponse with error`() {
+        // language=json
+        val payload =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "error": {
+                "code": -32001,
+                "message": "Task not found"
+              }
+            }
+            """.trimIndent()
+
+        val model = deserializeAndSerialize<DeleteTaskPushNotificationConfigResponse>(payload)
+        model.id shouldBe 1
+        model.result shouldBe null
+        model.error?.code shouldBe -32001
+        model.error?.message shouldBe "Task not found"
+    }
+
+    @Test
+    fun `Deserialize and Serialize DeleteTaskPushNotificationConfigResponse with AuthenticatedExtendedCardNotConfiguredError`() {
+        // language=json
+        val payload =
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": "test-123",
+              "error": {
+                "code": -32007,
+                "message": "Authenticated Extended Card not configured"
+              }
+            }
+            """.trimIndent()
+
+        val model = deserializeAndSerialize<DeleteTaskPushNotificationConfigResponse>(payload)
+        model.id shouldBe "test-123"
+        model.result shouldBe null
+        model.error?.code shouldBe -32007
+        model.error?.message shouldBe "Authenticated Extended Card not configured"
+    }
+}

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/PartDiscriminatorTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/PartDiscriminatorTest.kt
@@ -1,0 +1,40 @@
+package me.kpavlov.aimocks.a2a.model
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+/**
+ * Test to verify that the Part polymorphic serialization works correctly with "kind" discriminator.
+ * This addresses the issue: "Class discriminator was missing and no default serializers were registered in the polymorphic scope of 'Part'."
+ */
+internal class PartDiscriminatorTest : AbstractSerializationTest() {
+    @Test
+    fun `should deserialize TextPart with kind discriminator`() {
+        // This is the exact JSON from the error message that was failing
+        val json = """{"kind":"text","text":"write a long paper describing the attached pictures"}"""
+
+        val part = deserializeAndSerialize<Part>(json)
+
+        part.shouldBeInstanceOf<TextPart>()
+        (part as TextPart).text shouldBe "write a long paper describing the attached pictures"
+    }
+
+    @Test
+    fun `should deserialize DataPart with kind discriminator`() {
+        val json = """{"kind":"data","data":{"key":"value"}}"""
+
+        val part = deserializeAndSerialize<Part>(json)
+
+        part.shouldBeInstanceOf<DataPart>()
+    }
+
+    @Test
+    fun `should deserialize FilePart with kind discriminator`() {
+        val json = """{"kind":"file","file":{"mimeType":"text/plain","uri":"https://example.com/file.txt"}}"""
+
+        val part = deserializeAndSerialize<Part>(json)
+
+        part.shouldBeInstanceOf<FilePart>()
+    }
+}

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilderTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/PushNotificationConfigBuilderTest.kt
@@ -22,7 +22,7 @@ internal class PushNotificationConfigBuilderTest {
     fun `should build PushNotificationConfig with all parameters`() {
         // when
         val config =
-            PushNotificationConfig.build {
+            PushNotificationConfig.create {
                 url = "https://example.org/notifications"
                 token = "auth-token"
             }

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilderTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/me/kpavlov/aimocks/a2a/model/TaskPushNotificationConfigBuilderTest.kt
@@ -117,7 +117,7 @@ internal class TaskPushNotificationConfigBuilderTest {
     fun `should build using companion object build function`() {
         // when
         val config =
-            TaskPushNotificationConfig.build {
+            TaskPushNotificationConfig.create {
                 id = "task-123"
                 pushNotificationConfig {
                     url = "https://example.org/notifications"

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/DeleteTaskPushNotificationConfigBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/DeleteTaskPushNotificationConfigBuildingStep.kt
@@ -1,0 +1,30 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.DeleteTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.core.AbstractBuildingStep
+import me.kpavlov.mokksy.BuildingStep
+import me.kpavlov.mokksy.MokksyServer
+
+/**
+ * Building step for configuring delete task push notification config responses.
+ */
+public class DeleteTaskPushNotificationConfigBuildingStep(
+    mokksy: MokksyServer,
+    buildingStep: BuildingStep<DeleteTaskPushNotificationConfigRequest>,
+) : AbstractBuildingStep<DeleteTaskPushNotificationConfigRequest, DeleteTaskPushNotificationConfigResponseSpecification>(
+        mokksy,
+        buildingStep,
+    ) {
+    override infix fun responds(
+        block: DeleteTaskPushNotificationConfigResponseSpecification.() -> Unit,
+    ) {
+        buildingStep.respondsWith {
+            val responseDefinition = this.build()
+            val responseSpec =
+                DeleteTaskPushNotificationConfigResponseSpecification(responseDefinition)
+            block.invoke(responseSpec)
+            delay = responseSpec.delay
+            body = responseSpec.build()
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/DeleteTaskPushNotificationConfigResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/DeleteTaskPushNotificationConfigResponseSpecification.kt
@@ -1,0 +1,55 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.DeleteTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.DeleteTaskPushNotificationConfigResponse
+import me.kpavlov.aimocks.a2a.model.JSONRPCError
+import me.kpavlov.aimocks.a2a.model.JSONRPCErrorBuilder
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+/**
+ * Response specification for configuring delete task push notification config responses.
+ */
+public class DeleteTaskPushNotificationConfigResponseSpecification(
+    response: AbstractResponseDefinition<DeleteTaskPushNotificationConfigResponse>,
+    delay: Duration = Duration.ZERO,
+) : AbstractResponseSpecification<DeleteTaskPushNotificationConfigRequest, DeleteTaskPushNotificationConfigResponse>(
+        response = response,
+        delay = delay,
+    ) {
+    public var id: RequestId? = null
+    public var result: Nothing? = null
+    public var error: JSONRPCError? = null
+
+    /**
+     * Sets the request ID.
+     */
+    public fun id(id: RequestId): DeleteTaskPushNotificationConfigResponseSpecification =
+        apply { this.id = id }
+
+    /**
+     * Sets the error using a lambda with receiver.
+     */
+    public fun error(
+        init: JSONRPCErrorBuilder<JSONRPCError, JSONRPCErrorBuilder<JSONRPCError, *>>.() -> Unit,
+    ): DeleteTaskPushNotificationConfigResponseSpecification =
+        apply {
+            this.error =
+                JSONRPCErrorBuilder<JSONRPCError, JSONRPCErrorBuilder<JSONRPCError, *>>()
+                    .apply(
+                        init,
+                    ).build()
+        }
+
+    /**
+     * Builds the response.
+     */
+    public fun build(): DeleteTaskPushNotificationConfigResponse =
+        DeleteTaskPushNotificationConfigResponse(
+            id = id,
+            result = result,
+            error = error,
+        )
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetAuthenticatedExtendedCardBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetAuthenticatedExtendedCardBuildingStep.kt
@@ -1,0 +1,29 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.GetAuthenticatedExtendedCardRequest
+import me.kpavlov.aimocks.core.AbstractBuildingStep
+import me.kpavlov.mokksy.BuildingStep
+import me.kpavlov.mokksy.MokksyServer
+
+/**
+ * Building step for configuring get authenticated extended card responses.
+ */
+public class GetAuthenticatedExtendedCardBuildingStep(
+    mokksy: MokksyServer,
+    buildingStep: BuildingStep<GetAuthenticatedExtendedCardRequest>,
+) : AbstractBuildingStep<GetAuthenticatedExtendedCardRequest, GetAuthenticatedExtendedCardResponseSpecification>(
+        mokksy,
+        buildingStep,
+    ) {
+    override infix fun responds(
+        block: GetAuthenticatedExtendedCardResponseSpecification.() -> Unit,
+    ) {
+        buildingStep.respondsWith {
+            val responseDefinition = this.build()
+            val responseSpec = GetAuthenticatedExtendedCardResponseSpecification(responseDefinition)
+            block.invoke(responseSpec)
+            delay = responseSpec.delay
+            body = responseSpec.build()
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetAuthenticatedExtendedCardResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/GetAuthenticatedExtendedCardResponseSpecification.kt
@@ -1,0 +1,52 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.AgentCard
+import me.kpavlov.aimocks.a2a.model.AgentCardBuilder
+import me.kpavlov.aimocks.a2a.model.GetAuthenticatedExtendedCardRequest
+import me.kpavlov.aimocks.a2a.model.GetAuthenticatedExtendedCardResponse
+import me.kpavlov.aimocks.a2a.model.JSONRPCError
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+/**
+ * Response specification for configuring get authenticated extended card responses.
+ */
+public class GetAuthenticatedExtendedCardResponseSpecification(
+    response: AbstractResponseDefinition<GetAuthenticatedExtendedCardResponse>,
+    delay: Duration = Duration.ZERO,
+) : AbstractResponseSpecification<GetAuthenticatedExtendedCardRequest, GetAuthenticatedExtendedCardResponse>(
+        response = response,
+        delay = delay,
+    ) {
+    public var id: RequestId? = null
+    public var result: AgentCard? = null
+    public var error: JSONRPCError? = null
+
+    /**
+     * Sets the request ID.
+     */
+    public fun id(id: RequestId): GetAuthenticatedExtendedCardResponseSpecification =
+        apply { this.id = id }
+
+    /**
+     * Sets the result using a lambda with receiver.
+     */
+    public fun result(
+        init: AgentCardBuilder.() -> Unit,
+    ): GetAuthenticatedExtendedCardResponseSpecification =
+        apply {
+            this.result = AgentCardBuilder().apply(init).build()
+        }
+
+    /**
+     * Builds the response.
+     */
+    public fun build(): GetAuthenticatedExtendedCardResponse =
+        GetAuthenticatedExtendedCardResponse(
+            id = id,
+            result = result,
+            error = error,
+        )
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/ListTaskPushNotificationConfigBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/ListTaskPushNotificationConfigBuildingStep.kt
@@ -1,0 +1,36 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigResponse
+import me.kpavlov.aimocks.core.AbstractBuildingStep
+import me.kpavlov.mokksy.BuildingStep
+import me.kpavlov.mokksy.MokksyServer
+
+public class ListTaskPushNotificationConfigBuildingStep(
+    mokksy: MokksyServer,
+    buildingStep: BuildingStep<ListTaskPushNotificationConfigRequest>,
+) : AbstractBuildingStep<
+        ListTaskPushNotificationConfigRequest,
+        ListTaskPushNotificationConfigResponseSpecification,
+    >(
+        mokksy,
+        buildingStep,
+    ) {
+    override infix fun responds(
+        block: ListTaskPushNotificationConfigResponseSpecification.() -> Unit,
+    ) {
+        buildingStep.respondsWith {
+            val requestBody = request.body
+            val responseDefinition = this.build()
+            val responseSpecification =
+                ListTaskPushNotificationConfigResponseSpecification(responseDefinition)
+            block.invoke(responseSpecification)
+            body =
+                ListTaskPushNotificationConfigResponse(
+                    id = responseSpecification.id ?: requestBody.id,
+                    result = responseSpecification.result,
+                    error = responseSpecification.error,
+                )
+        }
+    }
+}

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/ListTaskPushNotificationConfigResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/ListTaskPushNotificationConfigResponseSpecification.kt
@@ -1,0 +1,21 @@
+package me.kpavlov.aimocks.a2a
+
+import me.kpavlov.aimocks.a2a.model.JSONRPCError
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigResponse
+import me.kpavlov.aimocks.a2a.model.RequestId
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.core.AbstractResponseSpecification
+import me.kpavlov.mokksy.response.AbstractResponseDefinition
+import kotlin.time.Duration
+
+public class ListTaskPushNotificationConfigResponseSpecification(
+    response: AbstractResponseDefinition<ListTaskPushNotificationConfigResponse>,
+    public var id: RequestId? = null,
+    public var result: List<TaskPushNotificationConfig>? = null,
+    public var error: JSONRPCError? = null,
+    delay: Duration = Duration.ZERO,
+) : AbstractResponseSpecification<ListTaskPushNotificationConfigRequest, ListTaskPushNotificationConfigResponse>(
+        response = response,
+        delay = delay,
+    )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -3,6 +3,8 @@ package me.kpavlov.aimocks.a2a
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
+import me.kpavlov.aimocks.a2a.model.DeleteTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.GetAuthenticatedExtendedCardRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
 import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigRequest
@@ -389,6 +391,25 @@ public open class MockAgentServer private constructor(
         )
     }
 
+    @JvmOverloads
+    public fun deleteTaskPushNotificationConfig(
+        name: String? = null,
+    ): DeleteTaskPushNotificationConfigBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = DeleteTaskPushNotificationConfigRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/pushNotificationConfig/delete"
+                    }
+                }
+
+        return DeleteTaskPushNotificationConfigBuildingStep(
+            mokksy = mokksy,
+            buildingStep = requestStep,
+        )
+    }
+
     /**
      * Configures the behavior of the mocking server to handle
      * [Resubscribe to a Task](https://a2a-protocol.org/latest/specification/) requests.
@@ -435,6 +456,25 @@ public open class MockAgentServer private constructor(
         return TaskResubscriptionBuildingStep(
             buildingStep = requestStep,
             mokksy = mokksy,
+        )
+    }
+
+    @JvmOverloads
+    public fun getAuthenticatedExtendedCard(
+        name: String? = null,
+    ): GetAuthenticatedExtendedCardBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = GetAuthenticatedExtendedCardRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "agent/getAuthenticatedExtendedCard"
+                    }
+                }
+
+        return GetAuthenticatedExtendedCardBuildingStep(
+            mokksy = mokksy,
+            buildingStep = requestStep,
         )
     }
 

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/MockAgentServer.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import me.kpavlov.aimocks.a2a.model.CancelTaskRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskPushNotificationRequest
 import me.kpavlov.aimocks.a2a.model.GetTaskRequest
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigRequest
 import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
 import me.kpavlov.aimocks.a2a.model.SendMessageRequest
 import me.kpavlov.aimocks.a2a.model.SendStreamingMessageRequest
@@ -364,6 +365,25 @@ public open class MockAgentServer private constructor(
                 }
 
         return SetTaskPushNotificationBuildingStep(
+            buildingStep = requestStep,
+            mokksy = mokksy,
+        )
+    }
+
+    @JvmOverloads
+    public fun listTaskPushNotificationConfig(
+        name: String? = null,
+    ): ListTaskPushNotificationConfigBuildingStep {
+        val requestStep =
+            mokksy
+                .post(name = name, requestType = ListTaskPushNotificationConfigRequest::class) {
+                    path("/")
+                    bodyMatchesPredicate {
+                        it?.method == "tasks/pushNotificationConfig/list"
+                    }
+                }
+
+        return ListTaskPushNotificationConfigBuildingStep(
             buildingStep = requestStep,
             mokksy = mokksy,
         )

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendStreamingMessageBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendStreamingMessageBuildingStep.kt
@@ -16,7 +16,9 @@ public class SendStreamingMessageBuildingStep(
         mokksy,
         buildingStep,
     ) {
-    public override infix fun respondsStream(block: SendStreamingMessageResponseSpecification.() -> Unit) {
+    public override infix fun respondsStream(
+        block: SendStreamingMessageResponseSpecification.() -> Unit,
+    ) {
         buildingStep.respondsWithStream {
             val requestBody = request.body
             val responseDefinition = this.build()

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendStreamingMessageResponseSpecification.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/SendStreamingMessageResponseSpecification.kt
@@ -23,7 +23,9 @@ public class SendStreamingMessageResponseSpecification(
     /**
      * Java-friendly setter for [responseFlow].
      */
-    public fun responseFlow(flow: Flow<TaskUpdateEvent>): SendStreamingMessageResponseSpecification =
+    public fun responseFlow(
+        flow: Flow<TaskUpdateEvent>,
+    ): SendStreamingMessageResponseSpecification =
         apply {
             this.responseFlow = flow
         }
@@ -31,7 +33,11 @@ public class SendStreamingMessageResponseSpecification(
     public fun delayBetweenChunks(delay: Duration): SendStreamingMessageResponseSpecification =
         apply { this.delayBetweenChunks = delay }
 
-    public fun delay(delay: Duration): SendStreamingMessageResponseSpecification = apply { this.delay = delay }
+    public fun delay(delay: Duration): SendStreamingMessageResponseSpecification =
+        apply {
+            this.delay =
+                delay
+        }
 
     public fun stream(stream: Stream<TaskUpdateEvent>): SendStreamingMessageResponseSpecification =
         apply { this.responseFlow = stream.consumeAsFlow() }

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/TaskResubscriptionBuildingStep.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/TaskResubscriptionBuildingStep.kt
@@ -19,7 +19,9 @@ public class TaskResubscriptionBuildingStep(
         mokksy,
         buildingStep,
     ) {
-    public override infix fun respondsStream(block: TaskResubscriptionResponseSpecification.() -> Unit) {
+    public override infix fun respondsStream(
+        block: TaskResubscriptionResponseSpecification.() -> Unit,
+    ) {
         buildingStep.respondsWithStream {
             val requestBody = request.body
             val responseDefinition = this.build()

--- a/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/TaskNotificationHistory.kt
+++ b/ai-mocks-a2a/src/commonMain/kotlin/me/kpavlov/aimocks/a2a/notifications/TaskNotificationHistory.kt
@@ -24,7 +24,8 @@ public class TaskNotificationHistory(
 
     internal fun isNotEmpty(): Boolean = !isEmpty()
 
-    internal fun find(predicate: (TaskUpdateEvent) -> Boolean): TaskUpdateEvent? = events.find(predicate)
+    internal fun find(predicate: (TaskUpdateEvent) -> Boolean): TaskUpdateEvent? =
+        events.find(predicate)
 
     internal fun extract(predicate: (TaskUpdateEvent) -> Boolean): List<TaskUpdateEvent> {
         events.filter(predicate).also { found ->

--- a/ai-mocks-a2a/src/jvmMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingResponseSpecification.jvm.kt
+++ b/ai-mocks-a2a/src/jvmMain/kotlin/me/kpavlov/aimocks/a2a/SendTaskStreamingResponseSpecification.jvm.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.runBlocking
 import me.kpavlov.aimocks.a2a.model.TaskUpdateEvent
 import java.util.concurrent.Flow
 
-public fun SendStreamingMessageResponseSpecification.publisher(publisher: Flow.Publisher<TaskUpdateEvent>) {
+public fun SendStreamingMessageResponseSpecification.publisher(
+    publisher: Flow.Publisher<TaskUpdateEvent>,
+) {
     responseFlow =
         flow {
             publisher.subscribe(

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/DeleteTaskPushNotificationConfigTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/DeleteTaskPushNotificationConfigTest.kt
@@ -1,0 +1,97 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.DeleteTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.DeleteTaskPushNotificationConfigResponse
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.deleteTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.invalidParamsError
+import kotlin.test.Test
+
+internal class DeleteTaskPushNotificationConfigTest : AbstractTest() {
+    /**
+     * https://a2a-protocol.org/latest/specification/#78-taskspushnotificationconfigdelete
+     */
+    @Test
+    fun `Should delete TaskPushNotification config`() =
+        runTest {
+            val taskId: TaskId = "task_12345"
+
+            a2aServer.deleteTaskPushNotificationConfig() responds {
+                id = 1
+                result = null
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            deleteTaskPushNotificationConfigRequest {
+                                id = "1"
+                                params {
+                                    id = taskId
+                                }
+                            }
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonRpcRequest)
+                    }.call
+                    .response
+
+            response.status shouldBe HttpStatusCode.OK
+            val payload = response.body<DeleteTaskPushNotificationConfigResponse>()
+
+            val expectedReply =
+                DeleteTaskPushNotificationConfigResponse(
+                    id = 1,
+                    result = null,
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+
+    @Test
+    fun `Should fail to delete TaskPushNotification config`() =
+        runTest {
+
+            a2aServer.deleteTaskPushNotificationConfig() responds {
+                id = 1
+                error {
+                    code = -32602
+                    message = "Invalid parameters"
+                }
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            DeleteTaskPushNotificationConfigRequest(
+                                id = "1",
+                                params = null,
+                            )
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonRpcRequest)
+                    }.call
+                    .response
+
+            response.status shouldBe HttpStatusCode.OK
+            val payload = response.body<DeleteTaskPushNotificationConfigResponse>()
+
+            val expectedReply =
+                DeleteTaskPushNotificationConfigResponse(
+                    id = 1,
+                    error =
+                        invalidParamsError {
+                            message = "Invalid parameters"
+                        },
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/GetAuthenticatedExtendedCardTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/GetAuthenticatedExtendedCardTest.kt
@@ -1,0 +1,159 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.AgentCard
+import me.kpavlov.aimocks.a2a.model.AgentProvider
+import me.kpavlov.aimocks.a2a.model.GetAuthenticatedExtendedCardRequest
+import me.kpavlov.aimocks.a2a.model.GetAuthenticatedExtendedCardResponse
+import me.kpavlov.aimocks.a2a.model.agentAuthentication
+import me.kpavlov.aimocks.a2a.model.agentCapabilities
+import me.kpavlov.aimocks.a2a.model.agentSkill
+import me.kpavlov.aimocks.a2a.model.getAuthenticatedExtendedCardRequest
+import me.kpavlov.aimocks.a2a.model.invalidParamsError
+import kotlin.test.Test
+
+internal class GetAuthenticatedExtendedCardTest : AbstractTest() {
+    /**
+     * https://a2a-protocol.org/latest/specification/#710-agentgetauthenticatedextendedcard
+     */
+    @Test
+    fun `Should get authenticated extended agent card`() =
+        runTest {
+            val agentCard =
+                AgentCard(
+                    name = "Test Agent",
+                    description = "Test Agent Description",
+                    url = "https://example.com/agent",
+                    provider =
+                        AgentProvider(
+                            organization = "Test Organization",
+                            url = "https://example.com/organization",
+                        ),
+                    version = "1.0.0",
+                    documentationUrl = "https://example.com/docs",
+                    capabilities =
+                        agentCapabilities {
+                            streaming = true
+                            pushNotifications = true
+                        },
+                    authentication =
+                        agentAuthentication {
+                            schemes = listOf("none", "bearer")
+                            credentials = "test-token"
+                        },
+                    defaultInputModes = listOf("text", "voice"),
+                    defaultOutputModes = listOf("text", "audio"),
+                    skills =
+                        listOf(
+                            agentSkill {
+                                id = "test-skill"
+                                name = "Test Skill"
+                                description = "A test skill for demonstration"
+                            },
+                        ),
+                    signatures = listOf("sig1", "sig2"),
+                    supportsAuthenticatedExtendedCard = true,
+                )
+
+            a2aServer.getAuthenticatedExtendedCard() responds {
+                id = 1
+                result {
+                    name = "Test Agent"
+                    description = "Test Agent Description"
+                    url = "https://example.com/agent"
+                    provider {
+                        organization = "Test Organization"
+                        url = "https://example.com/organization"
+                    }
+                    version = "1.0.0"
+                    documentationUrl = "https://example.com/docs"
+                    capabilities {
+                        streaming = true
+                        pushNotifications = true
+                    }
+                    authentication {
+                        schemes = listOf("none", "bearer")
+                        credentials = "test-token"
+                    }
+                    defaultInputModes = listOf("text", "voice")
+                    defaultOutputModes = listOf("text", "audio")
+                    addSkill(
+                        agentSkill {
+                            id = "test-skill"
+                            name = "Test Skill"
+                            description = "A test skill for demonstration"
+                        },
+                    )
+                    signatures = mutableListOf("sig1", "sig2")
+                    supportsAuthenticatedExtendedCard = true
+                }
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            getAuthenticatedExtendedCardRequest {
+                                id = "1"
+                            }
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonRpcRequest)
+                    }.call
+                    .response
+
+            response.status shouldBe HttpStatusCode.OK
+            val payload = response.body<GetAuthenticatedExtendedCardResponse>()
+
+            val expectedReply =
+                GetAuthenticatedExtendedCardResponse(
+                    id = 1,
+                    result = agentCard,
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+
+    @Test
+    fun `Should fail to get authenticated extended agent card`() =
+        runTest {
+            a2aServer.getAuthenticatedExtendedCard() responds {
+                id = 1
+                error =
+                    invalidParamsError {
+                        message = "Authenticated Extended Card not configured"
+                    }
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            GetAuthenticatedExtendedCardRequest(
+                                id = "1",
+                            )
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonRpcRequest)
+                    }.call
+                    .response
+
+            response.status shouldBe HttpStatusCode.OK
+            val payload = response.body<GetAuthenticatedExtendedCardResponse>()
+
+            val expectedReply =
+                GetAuthenticatedExtendedCardResponse(
+                    id = 1,
+                    error =
+                        invalidParamsError {
+                            message = "Authenticated Extended Card not configured"
+                        },
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+}

--- a/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/ListTaskPushNotificationConfigTest.kt
+++ b/ai-mocks-a2a/src/jvmTest/kotlin/me/kpavlov/aimocks/a2a/ListTaskPushNotificationConfigTest.kt
@@ -1,0 +1,131 @@
+package me.kpavlov.aimocks.a2a
+
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.a2a.model.AuthenticationInfo
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigRequest
+import me.kpavlov.aimocks.a2a.model.ListTaskPushNotificationConfigResponse
+import me.kpavlov.aimocks.a2a.model.PushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.TaskId
+import me.kpavlov.aimocks.a2a.model.TaskPushNotificationConfig
+import me.kpavlov.aimocks.a2a.model.invalidParamsError
+import me.kpavlov.aimocks.a2a.model.listTaskPushNotificationConfigRequest
+import kotlin.test.Test
+
+internal class ListTaskPushNotificationConfigTest : AbstractTest() {
+    /**
+     * https://a2a-protocol.org/latest/specification/#77-taskspushnotificationconfiglist
+     */
+    @Test
+    fun `Should list TaskPushNotification configs`() =
+        runTest {
+            val taskId1: TaskId = "task_12345"
+            val taskId2: TaskId = "task_67890"
+
+            val config1 =
+                TaskPushNotificationConfig(
+                    id = taskId1,
+                    pushNotificationConfig =
+                        PushNotificationConfig(
+                            url = "https://example.com/callback1",
+                            token = "abc.def.jk1",
+                            authentication =
+                                AuthenticationInfo(
+                                    schemes = listOf("Bearer"),
+                                ),
+                        ),
+                )
+
+            val config2 =
+                TaskPushNotificationConfig(
+                    id = taskId2,
+                    pushNotificationConfig =
+                        PushNotificationConfig(
+                            url = "https://example.com/callback2",
+                            token = "abc.def.jk2",
+                            authentication =
+                                AuthenticationInfo(
+                                    schemes = listOf("Basic"),
+                                ),
+                        ),
+                )
+
+            val configList = listOf(config1, config2)
+
+            a2aServer.listTaskPushNotificationConfig() responds {
+                id = 1
+                result = configList
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            listTaskPushNotificationConfigRequest {
+                                id = "1"
+                                params {
+                                    limit = 10
+                                    offset = 0
+                                }
+                            }
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonRpcRequest)
+                    }.call
+                    .response
+
+            response.status shouldBe HttpStatusCode.OK
+            val payload = response.body<ListTaskPushNotificationConfigResponse>()
+
+            val expectedReply =
+                ListTaskPushNotificationConfigResponse(
+                    id = 1,
+                    result = configList,
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+
+    @Test
+    fun `Should fail to list TaskPushNotification configs`() =
+        runTest {
+            a2aServer.listTaskPushNotificationConfig() responds {
+                id = 1
+                error =
+                    invalidParamsError {
+                        message = "Invalid parameters"
+                    }
+            }
+
+            val response =
+                a2aClient
+                    .post("/") {
+                        val jsonRpcRequest =
+                            ListTaskPushNotificationConfigRequest(
+                                id = "1",
+                                params = null,
+                            )
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonRpcRequest)
+                    }.call
+                    .response
+
+            response.status shouldBe HttpStatusCode.OK
+            val payload = response.body<ListTaskPushNotificationConfigResponse>()
+
+            val expectedReply =
+                ListTaskPushNotificationConfigResponse(
+                    id = 1,
+                    error =
+                        invalidParamsError {
+                            message = "Invalid parameters"
+                        },
+                )
+            payload shouldBeEqualToComparingFields expectedReply
+        }
+}

--- a/ai-mocks-gemini/src/jvmTest/java/me/kpavlov/aimocks/gemini/MockGeminiJavaStreamingTest.java
+++ b/ai-mocks-gemini/src/jvmTest/java/me/kpavlov/aimocks/gemini/MockGeminiJavaStreamingTest.java
@@ -53,6 +53,8 @@ class MockGeminiJavaStreamingTest {
     private long topKValue;
     private long maxCompletionTokensValue;
     private String modelName;
+    private String systemMessage;
+    private String userMessage;
 
     @BeforeEach
     void beforeEach() {
@@ -68,12 +70,14 @@ class MockGeminiJavaStreamingTest {
         topKValue = RANDOM.nextLong(1, 42);
         temperatureValue = RANDOM.nextDouble(0.0, 1.0);
         maxCompletionTokensValue = RANDOM.nextLong(100, 500);
+
+        systemMessage = "You are a helpful pirate." + seedValue;
+        userMessage = "Just say 'Hello!'" + seedValue;
     }
 
     @Test
     void shouldRespondWithStreamToGenerateContentStream() {
         // Configure the mock server to respond with a stream
-        final var systemMessage = "You are a helpful pirate." + seedValue;
         MOCK.generateContentStream(req -> {
             req.temperature(temperatureValue);
             req.apiVersion("v1beta1");
@@ -81,11 +85,10 @@ class MockGeminiJavaStreamingTest {
             req.maxOutputTokens(maxCompletionTokensValue);
             req.model(modelName);
             req.project(PROJECT_ID);
-            req.seed(seedValue);
             req.systemMessageContains(systemMessage);
             req.topK(topKValue);
             req.topP(topPValue);
-            req.userMessageContains("Just say 'Hello!'");
+            req.userMessageContains(userMessage);
         }).respondsStream(response -> {
             response.stream(
                 Stream.of("Ahoy", " there,", " matey!", " Hello!")
@@ -100,7 +103,7 @@ class MockGeminiJavaStreamingTest {
         try (
             ResponseStream<GenerateContentResponse> responseStream = CLIENT.models.generateContentStream(
                 modelName,
-                "Just say 'Hello!'",
+                userMessage,
                 config
             )) {
 
@@ -130,11 +133,11 @@ class MockGeminiJavaStreamingTest {
             req.model(modelName);
             req.project(PROJECT_ID);
             req.seed(seedValue);
-            req.systemMessageContains("You are a helpful pirate");
+            req.systemMessageContains(systemMessage);
             req.temperature(temperatureValue);
             req.topK(topKValue);
             req.topP(topPValue);
-            req.userMessageContains("Just say 'Hello!'");
+            req.userMessageContains(userMessage);
         }).respondsStream(response -> {
             response.stream(
                 Stream.of("Ahoy", " there,", " matey!", " Hello!")
@@ -151,7 +154,7 @@ class MockGeminiJavaStreamingTest {
         assertThatThrownBy(() -> {
             try (var ignored = CLIENT.models.generateContentStream(
                 modelName,
-                "Just say 'Hello!'",
+                userMessage,
                 config
             )) {
                 fail("No stream should be returned");


### PR DESCRIPTION

Adds A2A mock server features (list/delete task push-notification configs, get authenticated extended card): new serializable request/response models, DSL builders, response specifications, building steps, MockAgentServer endpoints, Java Consumer overloads, tests, and many formatting/signature reflows across ai-mocks modules plus a small docs guideline addition.