### PR TITLE
chore: Enable parallel test execution for JUnit in all modules

### DIFF
--- a/ai-mocks-a2a/src/jvmTest/resources/junit-platform.properties
+++ b/ai-mocks-a2a/src/jvmTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ai-mocks-core/src/jvmTest/resources/junit-platform.properties
+++ b/ai-mocks-core/src/jvmTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/AbstractMockGeminiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/AbstractMockGeminiTest.kt
@@ -1,9 +1,7 @@
 package me.kpavlov.aimocks.gemini
 
-import com.google.cloud.vertexai.VertexAI
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import java.time.Instant
@@ -23,24 +21,16 @@ internal abstract class AbstractMockGeminiTest {
     protected val logger = KotlinLogging.logger(name = this::class.simpleName!!)
     protected lateinit var startTimestamp: Instant
 
-    protected lateinit var projectId: String
-    protected lateinit var locationId: String
+    protected val projectId: String = "1234567890"
+    protected val locationId: String = "amsterdam-central1"
 
-    protected lateinit var vertexAI: VertexAI
-
-    @BeforeAll
-    fun beforeAll() {
-        projectId = "1234567890"
-        locationId = "us-central1"
-
-        vertexAI =
-            createTestVertexAI(
-                endpoint = gemini.baseUrl(),
-                projectId = projectId,
-                location = locationId,
-                timeout = 10.seconds,
-            )
-    }
+    protected val vertexAI =
+        createTestVertexAI(
+            endpoint = gemini.baseUrl(),
+            projectId = projectId,
+            location = locationId,
+            timeout = 10.seconds,
+        )
 
     @BeforeEach
     fun beforeEach() {

--- a/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/genai/AbstractGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/genai/AbstractGenaiTest.kt
@@ -9,26 +9,21 @@ import com.google.genai.types.HttpOptions
 import com.google.genai.types.Part
 import me.kpavlov.aimocks.gemini.AbstractMockGeminiTest
 import me.kpavlov.aimocks.gemini.gemini
-import org.junit.jupiter.api.BeforeAll
+import kotlin.random.Random
 
 internal abstract class AbstractGenaiTest : AbstractMockGeminiTest() {
-    protected lateinit var client: Client
-
-    @BeforeAll
-    fun createChatClient() {
-        client =
-            Client
-                .builder()
-                .project(projectId)
-                .location(locationId)
-                .credentials(
-                    GoogleCredentials.create(
-                        AccessToken.newBuilder().setTokenValue("dummy-token").build(),
-                    ),
-                ).vertexAI(true)
-                .httpOptions(HttpOptions.builder().baseUrl(gemini.baseUrl()).build())
-                .build()
-    }
+    protected val client =
+        Client
+            .builder()
+            .project(projectId)
+            .location(locationId)
+            .credentials(
+                GoogleCredentials.create(
+                    AccessToken.newBuilder().setTokenValue("dummy-token").build(),
+                ),
+            ).vertexAI(true)
+            .httpOptions(HttpOptions.builder().baseUrl(gemini.baseUrl()).build())
+            .build()
 
     protected fun generateContentConfig(systemPrompt: String): GenerateContentConfig.Builder =
         GenerateContentConfig
@@ -48,9 +43,9 @@ internal abstract class AbstractGenaiTest : AbstractMockGeminiTest() {
 
     protected fun requestMutators(): Array<GenerateContentConfig.Builder.() -> Unit> =
         arrayOf(
-            { topK(topKValue.toFloat() + 1) },
-            { topP(topPValue.toFloat() + 1) },
-            { temperature(temperatureValue.toFloat() / 2.0f) },
-            { maxOutputTokens(maxCompletionTokensValue.toInt() + 1) },
+            { topK(Random.nextDouble(0.1, 1.0).toFloat()) },
+            { topP(Random.nextDouble(0.1, 1.0).toFloat()) },
+            { temperature(Random.nextDouble(0.1, 1.0).toFloat()) },
+            { maxOutputTokens(Random.nextInt(100, 500)) },
         )
 }

--- a/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/genai/ChatCompletionGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/genai/ChatCompletionGenaiTest.kt
@@ -31,7 +31,7 @@ internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
         }
 
         val response =
-            client.models.generateContent(
+        client.models.generateContent(
                 modelName,
                 "Just say 'Hello!'",
                 generateContentConfig("You are a helpful pirate. $seedValue")
@@ -43,7 +43,9 @@ internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
 
     @ParameterizedTest
     @MethodSource("requestMutators")
-    fun `Should miss response when request does not match`(mutator: GenerateContentConfig.Builder.() -> Unit) {
+    fun `Should miss response when request does not match`(
+        mutator: GenerateContentConfig.Builder.() -> Unit,
+    ) {
         gemini.generateContent {
             temperature = temperatureValue
             seed = seedValue

--- a/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/springai/AbstractSpringAiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/me/kpavlov/aimocks/gemini/springai/AbstractSpringAiTest.kt
@@ -1,25 +1,21 @@
 package me.kpavlov.aimocks.gemini.springai
 
 import me.kpavlov.aimocks.gemini.AbstractMockGeminiTest
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel
 import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal abstract class AbstractSpringAiTest : AbstractMockGeminiTest() {
-    protected lateinit var chatClient: ChatClient
-
-    @BeforeAll
-    fun createChatClient() {
-        chatClient =
-            ChatClient
-                .builder(
-                    VertexAiGeminiChatModel
-                        .builder()
-                        .vertexAI(vertexAI)
-                        .build(),
-                ).build()
-    }
+    protected val chatClient: ChatClient =
+        ChatClient
+            .builder(
+                VertexAiGeminiChatModel
+                    .builder()
+                    .vertexAI(vertexAI)
+                    .build(),
+            ).build()
 
     protected fun prepareClientRequest(): ChatClient.ChatClientRequestSpec =
         chatClient

--- a/ai-mocks-gemini/src/jvmTest/resources/junit-platform.properties
+++ b/ai-mocks-gemini/src/jvmTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ai-mocks-ollama/src/jvmTest/resources/junit-platform.properties
+++ b/ai-mocks-ollama/src/jvmTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesFileInputTest.kt
@@ -10,28 +10,15 @@ import com.openai.models.responses.ResponseInputText
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContainIgnoringCase
 import me.kpavlov.aimocks.openai.openai
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
-import java.net.URL
 import java.util.UUID
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.measureTimedValue
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class ResponsesFileInputTest : AbstractOpenaiResponsesTest() {
-    private lateinit var imageResource: URL
-    private lateinit var filename: String
-    private lateinit var fileId: String
-
-    @OptIn(ExperimentalEncodingApi::class)
-    @BeforeAll
-    fun beforeAll() {
-        imageResource = this.javaClass.getResource("/pipiro.jpg")!!
-        filename = imageResource.file
-        fileId = UUID.randomUUID().toString()
-    }
+    private val imageResource = this.javaClass.getResource("/pipiro.jpg")!!
+    private val filename = imageResource.file
+    private val fileId = UUID.randomUUID().toString()
 
     @BeforeEach
     fun setupMock() {

--- a/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/me/kpavlov/aimocks/openai/official/responses/ResponsesImageInputTest.kt
@@ -11,11 +11,7 @@ import com.openai.models.responses.ResponseInputText
 import io.kotest.matchers.resource.resourceAsBytes
 import io.kotest.matchers.string.shouldContainIgnoringCase
 import me.kpavlov.aimocks.openai.openai
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestInstance.Lifecycle
-import java.net.URL
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.measureTimedValue
@@ -24,19 +20,12 @@ import kotlin.time.measureTimedValue
 private const val WIKIPEDIA_IMAGE_URL =
     "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
 
-@TestInstance(Lifecycle.PER_CLASS)
 internal class ResponsesImageInputTest : AbstractOpenaiResponsesTest() {
-    private lateinit var base64Image: String
-    private lateinit var imageResource: URL
-    private lateinit var base64ImageUrl: String
+    private val imageResource = this.javaClass.getResource("/pipiro.jpg")!!
 
     @OptIn(ExperimentalEncodingApi::class)
-    @BeforeAll
-    fun beforeAll() {
-        imageResource = this.javaClass.getResource("/pipiro.jpg")!!
-        base64Image = Base64.UrlSafe.encode(resourceAsBytes("/pipiro.jpg"))
-        base64ImageUrl = "data:image/jpeg;base64,$base64Image"
-    }
+    private val base64Image = Base64.UrlSafe.encode(resourceAsBytes("/pipiro.jpg"))
+    private val base64ImageUrl = "data:image/jpeg;base64,$base64Image"
 
     @Test
     @Suppress("LongMethod")

--- a/ai-mocks-openai/src/jvmTest/resources/junit-platform.properties
+++ b/ai-mocks-openai/src/jvmTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/mokksy/src/jvmTest/resources/junit-platform.properties
+++ b/mokksy/src/jvmTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
Enabled parallel execution for JUnit 5 test suites across all subprojects.
Simplify test setup by replacing `@BeforeAll` methods with property initialization