### PR TITLE
 Support JSON schema for function parameters in chat models

### DIFF
--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/json/schema/SchemaHelper.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/json/schema/SchemaHelper.kt
@@ -1,0 +1,116 @@
+package me.kpavlov.aimocks.core.json.schema
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Helper object for working with JSON schemas.
+ *
+ * Provides utility functions for parsing and validating JSON Schema definitions.
+ */
+public object SchemaHelper {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+        }
+
+    /**
+     * Parses a [JsonElement] into a [SchemaDefinition].
+     *
+     * @param schemaJson The JSON element containing the schema
+     * @return The parsed schema definition, or null if parsing fails
+     */
+    public fun parseSchema(schemaJson: JsonElement?): SchemaDefinition? =
+        schemaJson?.let {
+            try {
+                json.decodeFromJsonElement(SchemaDefinition.serializer(), it)
+            } catch (_: SerializationException) {
+                null
+            }
+        }
+
+    /**
+     * Checks if a schema has a property with the specified name.
+     *
+     * @param schema The schema definition to check
+     * @param propertyName The name of the property
+     * @return true if the property exists, false otherwise
+     */
+    public fun hasProperty(
+        schema: SchemaDefinition,
+        propertyName: String,
+    ): Boolean = schema.properties.containsKey(propertyName)
+
+    /**
+     * Gets the types of a property in the schema.
+     *
+     * @param schema The schema definition
+     * @param propertyName The name of the property
+     * @return The list of types for the property, or null if not found or not a value property
+     */
+    public fun getPropertyType(
+        schema: SchemaDefinition,
+        propertyName: String,
+    ): List<String>? =
+        schema.properties[propertyName]?.let { prop ->
+            when (prop) {
+                is ValuePropertyDefinition -> prop.type
+                else -> null
+            }
+        }
+
+    /**
+     * Checks if a property is required in the schema.
+     *
+     * @param schema The schema definition
+     * @param propertyName The name of the property
+     * @return true if the property is required, false otherwise
+     */
+    public fun isPropertyRequired(
+        schema: SchemaDefinition,
+        propertyName: String,
+    ): Boolean = schema.required.contains(propertyName)
+
+    /**
+     * Checks if all specified properties are required in the schema.
+     *
+     * @param schema The schema definition
+     * @param propertyNames The names of properties to check
+     * @return true if all properties are required, false otherwise
+     */
+    public fun hasAllRequiredProperties(
+        schema: SchemaDefinition,
+        vararg propertyNames: String,
+    ): Boolean = propertyNames.all { it in schema.required }
+
+    /**
+     * Gets the property definition for a given property name.
+     *
+     * @param schema The schema definition
+     * @param propertyName The name of the property
+     * @return The property definition, or null if not found
+     */
+    public fun getProperty(
+        schema: SchemaDefinition,
+        propertyName: String,
+    ): PropertyDefinition? = schema.properties[propertyName]
+
+    /**
+     * Gets the description of a property in the schema.
+     *
+     * @param schema The schema definition
+     * @param propertyName The name of the property
+     * @return The description of the property, or null if not found
+     */
+    public fun getPropertyDescription(
+        schema: SchemaDefinition,
+        propertyName: String,
+    ): String? =
+        schema.properties[propertyName]?.let { prop ->
+            when (prop) {
+                is ValuePropertyDefinition -> prop.description
+                else -> null
+            }
+        }
+}

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/Model.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/Model.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import me.kpavlov.aimocks.core.json.schema.JsonSchema
 import me.kpavlov.aimocks.openai.model.ChatCompletionRole
 import me.kpavlov.aimocks.openai.model.ChatCompletionStreamOptions
@@ -238,7 +239,7 @@ public data class FunctionObject(
     @SerialName(value = "name") @Required val name: String,
     @SerialName(value = "description") val description: String? = null,
     @SerialName(value = "parameters")
-    val parameters: Map<String, String>? = null,
+    val parameters: JsonElement? = null,
     @SerialName(value = "strict") val strict: Boolean? = false,
 )
 

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiChatCompletionRequestSpecification.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiChatCompletionRequestSpecification.kt
@@ -39,4 +39,71 @@ public open class OpenaiChatCompletionRequestSpecification(
     override fun userMessageContains(substring: String) {
         requestBody.add(OpenaiCompletionsMatchers.userMessageContains(substring))
     }
+
+    /**
+     * Adds a matcher to verify that the request includes a tool with the specified function name.
+     *
+     * @param functionName The name of the function to match
+     */
+    public fun hasToolWithFunction(functionName: String) {
+        requestBody.add(OpenaiCompletionsMatchers.hasToolWithFunction(functionName))
+    }
+
+    /**
+     * Adds a matcher to verify that a tool's function has a parameter with the specified name.
+     *
+     * @param functionName The name of the function
+     * @param parameterName The name of the parameter to check
+     */
+    public fun toolHasParameter(
+        functionName: String,
+        parameterName: String,
+    ) {
+        requestBody.add(OpenaiCompletionsMatchers.toolHasParameter(functionName, parameterName))
+    }
+
+    /**
+     * Adds a matcher to verify that a tool's function has a parameter with the specified name and description.
+     *
+     * @param functionName The name of the function
+     * @param parameterName The name of the parameter to check
+     * @param description The expected description of the parameter
+     */
+    public fun toolHasParameter(
+        functionName: String,
+        parameterName: String,
+        description: String,
+    ) {
+        requestBody.add(OpenaiCompletionsMatchers.toolHasParameter(functionName, parameterName, description))
+    }
+
+    /**
+     * Adds a matcher to verify that a tool's function parameter has the specified type.
+     *
+     * @param functionName The name of the function
+     * @param parameterName The name of the parameter
+     * @param expectedType The expected type (e.g., "string", "integer", "number", "boolean", "object", "array")
+     */
+    public fun toolParameterHasType(
+        functionName: String,
+        parameterName: String,
+        expectedType: String,
+    ) {
+        requestBody.add(
+            OpenaiCompletionsMatchers.toolParameterHasType(functionName, parameterName, expectedType),
+        )
+    }
+
+    /**
+     * Adds a matcher to verify that a tool's function requires specific parameters.
+     *
+     * @param functionName The name of the function
+     * @param requiredParams The parameter names that should be required
+     */
+    public fun toolRequiresParameters(
+        functionName: String,
+        vararg requiredParams: String,
+    ) {
+        requestBody.add(OpenaiCompletionsMatchers.toolRequiresParameters(functionName, *requiredParams))
+    }
 }

--- a/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiCompletionsMatchers.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/me/kpavlov/aimocks/openai/completions/OpenaiCompletionsMatchers.kt
@@ -2,6 +2,7 @@ package me.kpavlov.aimocks.openai.completions
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
+import me.kpavlov.aimocks.core.json.schema.SchemaHelper
 import me.kpavlov.aimocks.openai.ChatCompletionRequest
 import me.kpavlov.aimocks.openai.model.ChatCompletionRole
 
@@ -44,5 +45,175 @@ internal object OpenaiCompletionsMatchers {
                 )
 
             override fun toString(): String = "User message should contain \"$string\""
+        }
+
+    /**
+     * Matches requests that have a tool with the specified function name.
+     *
+     * @param functionName The name of the function to match
+     * @return A matcher that checks if the request contains a tool with the specified function name
+     */
+    fun hasToolWithFunction(functionName: String): Matcher<ChatCompletionRequest?> =
+        object : Matcher<ChatCompletionRequest?> {
+            override fun test(value: ChatCompletionRequest?): MatcherResult =
+                MatcherResult.Companion(
+                    value?.tools?.any { tool ->
+                        tool.function.name == functionName
+                    } == true,
+                    { "Request should have tool with function name \"$functionName\"" },
+                    { "Request should not have tool with function name \"$functionName\"" },
+                )
+
+            override fun toString(): String =
+                "Request should have tool with function name \"$functionName\""
+        }
+
+    /**
+     * Matches requests where a tool's function has a parameter with the specified name.
+     *
+     * @param functionName The name of the function
+     * @param parameterName The name of the parameter to check
+     * @return A matcher that checks if the specified function has the named parameter
+     */
+    fun toolHasParameter(
+        functionName: String,
+        parameterName: String,
+    ): Matcher<ChatCompletionRequest?> =
+        object : Matcher<ChatCompletionRequest?> {
+            override fun test(value: ChatCompletionRequest?): MatcherResult {
+                val tool = value?.tools?.find { it.function.name == functionName }
+                val schema = tool?.function?.parameters?.let { SchemaHelper.parseSchema(it) }
+                val hasParameter =
+                    schema?.let { SchemaHelper.hasProperty(it, parameterName) } == true
+
+                return MatcherResult.Companion(
+                    hasParameter,
+                    { "Function \"$functionName\" should have parameter \"$parameterName\"" },
+                    { "Function \"$functionName\" should not have parameter \"$parameterName\"" },
+                )
+            }
+
+            override fun toString(): String =
+                "Function \"$functionName\" should have parameter \"$parameterName\""
+        }
+
+    /**
+     * Matches requests where a tool's function has a parameter with the specified name and description.
+     *
+     * @param functionName The name of the function
+     * @param parameterName The name of the parameter to check
+     * @param description The expected description of the parameter
+     * @return A matcher that checks if the specified function has the named parameter with the given description
+     */
+    fun toolHasParameter(
+        functionName: String,
+        parameterName: String,
+        description: String,
+    ): Matcher<ChatCompletionRequest?> =
+        object : Matcher<ChatCompletionRequest?> {
+            override fun test(value: ChatCompletionRequest?): MatcherResult {
+                val tool = value?.tools?.find { it.function.name == functionName }
+                val schema = tool?.function?.parameters?.let { SchemaHelper.parseSchema(it) }
+                val actualDescription = schema?.let { SchemaHelper.getPropertyDescription(it, parameterName) }
+                val matches = actualDescription == description
+
+                return MatcherResult.Companion(
+                    matches,
+                    {
+                        "Function \"$functionName\" parameter \"$parameterName\" should have description \"$description\""
+                    },
+                    {
+                        "Function \"$functionName\" parameter \"$parameterName\" should not have description \"$description\""
+                    },
+                )
+            }
+
+            override fun toString(): String =
+                "Function \"$functionName\" parameter \"$parameterName\" should have description \"$description\""
+        }
+
+    /**
+     * Matches requests where a tool's function parameter has the specified type.
+     *
+     * @param functionName The name of the function
+     * @param parameterName The name of the parameter
+     * @param expectedType The expected type (e.g., "string", "integer", "number", "boolean", "object", "array")
+     * @return A matcher that checks if the parameter has the expected type
+     */
+    fun toolParameterHasType(
+        functionName: String,
+        parameterName: String,
+        expectedType: String,
+    ): Matcher<ChatCompletionRequest?> =
+        object : Matcher<ChatCompletionRequest?> {
+            override fun test(value: ChatCompletionRequest?): MatcherResult {
+                val tool = value?.tools?.find { it.function.name == functionName }
+                val schema = tool?.function?.parameters?.let { SchemaHelper.parseSchema(it) }
+                val actualTypes = schema?.let { SchemaHelper.getPropertyType(it, parameterName) }
+                val hasCorrectType = actualTypes?.contains(expectedType) == true
+
+                return MatcherResult.Companion(
+                    hasCorrectType,
+                    {
+                        "Function \"$functionName\" parameter \"$parameterName\" should have type \"$expectedType\""
+                    },
+                    {
+                        "Function \"$functionName\" parameter \"$parameterName\" should not have type \"$expectedType\""
+                    },
+                )
+            }
+
+            override fun toString(): String =
+                "Function \"$functionName\" parameter \"$parameterName\" should have type \"$expectedType\""
+        }
+
+    /**
+     * Matches requests where a tool's function schema requires specific parameters.
+     *
+     * @param functionName The name of the function
+     * @param requiredParams The list of parameter names that should be required
+     * @return A matcher that checks if all specified parameters are required
+     */
+    fun toolRequiresParameters(
+        functionName: String,
+        vararg requiredParams: String,
+    ): Matcher<ChatCompletionRequest?> =
+        object : Matcher<ChatCompletionRequest?> {
+            override fun test(value: ChatCompletionRequest?): MatcherResult {
+                val tool = value?.tools?.find { it.function.name == functionName }
+                val schema = tool?.function?.parameters?.let { SchemaHelper.parseSchema(it) }
+                val hasAllRequired =
+                    schema?.let {
+                        SchemaHelper.hasAllRequiredProperties(
+                            it,
+                            *requiredParams,
+                        )
+                    } == true
+
+                return MatcherResult.Companion(
+                    hasAllRequired,
+                    {
+                        "Function \"$functionName\" should require parameters: ${
+                            requiredParams.joinToString(
+                                ", ",
+                            )
+                        }"
+                    },
+                    {
+                        "Function \"$functionName\" should not require parameters: ${
+                            requiredParams.joinToString(
+                                ", ",
+                            )
+                        }"
+                    },
+                )
+            }
+
+            override fun toString(): String =
+                "Function \"$functionName\" should require parameters: ${
+                    requiredParams.joinToString(
+                        ", ",
+                    )
+                }"
         }
 }

--- a/ai-mocks-openai/src/commonTest/kotlin/me/kpavlov/aimocks/openai/model/chat/ChatCompletionModelsTest.kt
+++ b/ai-mocks-openai/src/commonTest/kotlin/me/kpavlov/aimocks/openai/model/chat/ChatCompletionModelsTest.kt
@@ -9,6 +9,8 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.instanceOf
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import me.kpavlov.aimocks.core.json.schema.StringPropertyDefinition
 import me.kpavlov.aimocks.openai.model.ChatCompletionRole
 import org.junit.jupiter.api.Test
@@ -70,7 +72,7 @@ internal class ChatCompletionModelsTest {
     }
 
     @Test
-    fun `Should deserialize structured ChatCompletionRequest`() {
+    fun `Should deserialize ChatCompletionRequest with single tool`() {
         val systemMessage = "You're a witty and wise assistant.\nYou are built with **RAG**"
         val json =
             """
@@ -82,7 +84,20 @@ internal class ChatCompletionModelsTest {
             ]},
             {"role":"user","content":"To be or not to be, 82460322?"}
             ],
-            "model":"gpt-4.1-mini","stream":false}
+            "model":"gpt-4.1-mini","stream":false,
+            "tools":[
+              {"function":{
+                "name":"stockPrice",
+                "description":"Returns stock price of given symbol",
+                "parameters":{
+                  "type":"object",
+                  "properties":{
+                    "symbol":{"description":"Stock symbol, e.g. APPL","type":"string"}},
+                    "required":["symbol"]}
+                },
+                "type":"function"}
+            ]
+            }
             """.trimIndent()
 
         val request = jsonParser.decodeFromString<ChatCompletionRequest>(json)
@@ -108,6 +123,76 @@ internal class ChatCompletionModelsTest {
             withClue("Second user message should be correct") {
                 messages[2].role shouldBe ChatCompletionRole.USER
                 messages[2].content shouldBe MessageContent.Text("To be or not to be, 82460322?")
+            }
+
+            withClue("Tools should be present") {
+                tools.shouldNotBeNull()
+                tools shouldHaveSize 1
+
+                withClue("Tool should be stockPrice function") {
+                    tools[0].type shouldBe "function"
+                    tools[0].function.name shouldBe "stockPrice"
+                    tools[0].function.description shouldBe "Returns stock price of given symbol"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Should deserialize ChatCompletionRequest with multiple tools`() {
+        val json =
+            """
+            {"messages":[
+            {"content":"You are a helpful assistant.","role":"system"},
+            {"content":"What's the weather and current time?","role":"user"}],
+            "model":"o1-mini",
+            "max_completion_tokens":102,
+            "seed":81619,
+            "temperature":0.9086965130658635,
+            "tools":[
+            {"function":{"name":"get_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"}},"required":["location"]}},"type":"function"},
+            {"function":{"name":"get_current_time","description":"Get the current time in a given timezone","parameters":{"type":"object","properties":{"timezone":{"type":"string","description":"The timezone, e.g. America/New_York"}},"required":["timezone"]}},"type":"function"}
+            ]}
+            """.trimIndent()
+
+        val request = jsonParser.decodeFromString<ChatCompletionRequest>(json)
+
+        assertSoftly(request) {
+            model shouldBe "o1-mini"
+            temperature shouldBe 0.9086965130658635
+            stream shouldBe false
+            messages shouldHaveSize 2
+            maxCompletionTokens shouldBe 102
+            seed shouldBe 81619
+
+            withClue("System message should be correct") {
+                messages[0].role shouldBe ChatCompletionRole.SYSTEM
+                messages[0].content shouldBe MessageContent.Text("You are a helpful assistant.")
+            }
+
+            withClue("User message should be correct") {
+                messages[1].role shouldBe ChatCompletionRole.USER
+                messages[1].content shouldBe
+                    MessageContent.Text("What's the weather and current time?")
+            }
+
+            withClue("Tools should be present") {
+                tools.shouldNotBeNull()
+                tools shouldHaveSize 2
+
+                withClue("First tool should be weather function") {
+                    tools[0].type shouldBe "function"
+                    tools[0].function.name shouldBe "get_weather"
+                    tools[0].function.description shouldBe
+                        "Get the current weather in a given location"
+                }
+
+                withClue("Second tool should be time function") {
+                    tools[1].type shouldBe "function"
+                    tools[1].function.name shouldBe "get_current_time"
+                    tools[1].function.description shouldBe
+                        "Get the current time in a given timezone"
+                }
             }
         }
     }
@@ -474,16 +559,282 @@ internal class ChatCompletionModelsTest {
                 assertSoftly(function) {
                     name shouldBe "get_weather"
                     description shouldBe "Get the current weather in a given location"
-                    parameters?.size shouldBe 2
 
                     withClue("Function parameters should be correct") {
-                        parameters?.get("location") shouldBe
+                        parameters.shouldNotBeNull()
+                        val paramsObj = parameters.jsonObject
+                        paramsObj.size shouldBe 2
+                        paramsObj["location"]?.jsonPrimitive?.content shouldBe
                             "The city and state, e.g. San Francisco, CA"
-                        parameters?.get("unit") shouldBe
+                        paramsObj["unit"]?.jsonPrimitive?.content shouldBe
                             "The temperature unit to use. Infer this from the user's location."
                     }
                 }
             }
+        }
+    }
+
+    @Test
+    fun `Should deserialize ChatCompletionRequest with image URL`() {
+        val json =
+            """
+            {
+              "model": "gpt-4o",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": "What's in this image?"
+                    },
+                    {
+                      "type": "image_url",
+                      "image_url": {
+                        "url": "https://example.com/image.jpg",
+                        "detail": "high"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "max_completion_tokens": 300
+            }
+            """.trimIndent()
+
+        val request = jsonParser.decodeFromString<ChatCompletionRequest>(json)
+
+        assertSoftly(request) {
+            model shouldBe "gpt-4o"
+            maxCompletionTokens shouldBe 300
+            messages shouldHaveSize 1
+
+            withClue("User message should contain text and image") {
+                messages[0].role shouldBe ChatCompletionRole.USER
+                val content = messages[0].content
+                content shouldBe instanceOf<MessageContent.Parts>()
+                val parts = (content as MessageContent.Parts).parts
+                parts shouldHaveSize 2
+
+                withClue("First part should be text") {
+                    parts[0] shouldBe instanceOf<ContentPart.Text>()
+                    (parts[0] as ContentPart.Text).text shouldBe "What's in this image?"
+                }
+
+                withClue("Second part should be image URL") {
+                    parts[1] shouldBe instanceOf<ContentPart.ImageUrl>()
+                    val imageUrl = parts[1] as ContentPart.ImageUrl
+                    imageUrl.imageUrl.url shouldBe "https://example.com/image.jpg"
+                    imageUrl.imageUrl.detail shouldBe "high"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Should deserialize ChatCompletionRequest with tool choice`() {
+        val json =
+            """
+            {
+              "model": "gpt-4o",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "What's the weather in Boston?"
+                }
+              ],
+              "tools": [
+                {
+                  "type": "function",
+                  "function": {
+                    "name": "get_current_weather",
+                    "description": "Get the current weather",
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "location": {
+                          "type": "string",
+                          "description": "The city and state, e.g. San Francisco, CA"
+                        },
+                        "format": {
+                          "type": "string",
+                          "enum": ["celsius", "fahrenheit"],
+                          "description": "The temperature unit to use."
+                        }
+                      },
+                      "required": ["location", "format"]
+                    }
+                  }
+                }
+              ],
+              "tool_choice": "auto"
+            }
+            """.trimIndent()
+
+        val request = jsonParser.decodeFromString<ChatCompletionRequest>(json)
+
+        assertSoftly(request) {
+            model shouldBe "gpt-4o"
+            messages shouldHaveSize 1
+            tools.shouldNotBeNull()
+            tools shouldHaveSize 1
+
+            withClue("Tool choice should be auto") {
+                toolChoice shouldBe instanceOf<ToolChoice.Auto>()
+            }
+
+            withClue("Tool should have enum parameter") {
+                val tool = tools[0]
+                tool.function.name shouldBe "get_current_weather"
+            }
+        }
+    }
+
+    @Test
+    fun `Should deserialize ChatResponse with tool calls`() {
+        val json =
+            """
+            {
+              "id": "chatcmpl-abc123",
+              "object": "chat.completions",
+              "created": 1699896916,
+              "model": "gpt-4o-2024-08-06",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [
+                      {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                          "name": "get_current_weather",
+                          "arguments": "{\"location\":\"Boston, MA\",\"format\":\"fahrenheit\"}"
+                        }
+                      }
+                    ]
+                  },
+                  "finish_reason": "tool_calls"
+                }
+              ],
+              "usage": {
+                "prompt_tokens": 82,
+                "completion_tokens": 17,
+                "total_tokens": 99,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0,
+                  "accepted_prediction_tokens": 0,
+                  "rejected_prediction_tokens": 0
+                }
+              }
+            }
+            """.trimIndent()
+
+        val response = jsonParser.decodeFromString<ChatResponse>(json)
+
+        assertSoftly(response) {
+            id shouldBe "chatcmpl-abc123"
+            model shouldBe "gpt-4o-2024-08-06"
+            choices shouldHaveSize 1
+
+            withClue("Choice should have tool calls") {
+                val choice = choices[0]
+                choice.finishReason shouldBe "tool_calls"
+                choice.message.shouldNotBeNull()
+
+                withClue("Message should have tool calls") {
+                    val message = choice.message
+                    val toolCalls = message?.toolCalls
+                    toolCalls.shouldNotBeNull()
+                    toolCalls shouldHaveSize 1
+
+                    val toolCall = toolCalls[0]
+                    toolCall.id shouldBe "call_abc123"
+                    toolCall.type shouldBe "function"
+                    toolCall.function.name shouldBe "get_current_weather"
+                    toolCall.function.arguments shouldBe
+                        "{\"location\":\"Boston, MA\",\"format\":\"fahrenheit\"}"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Should deserialize ChatCompletionRequest with audio input`() {
+        val json =
+            """
+            {
+              "model": "gpt-4o-audio-preview",
+              "modalities": ["text", "audio"],
+              "audio": {
+                "voice": "alloy",
+                "format": "wav"
+              },
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "input_audio",
+                      "input_audio": {
+                        "data": "BASE64_ENCODED_AUDIO",
+                        "format": "wav"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val request = jsonParser.decodeFromString<ChatCompletionRequest>(json)
+
+        assertSoftly(request) {
+            model shouldBe "gpt-4o-audio-preview"
+            messages shouldHaveSize 1
+
+            withClue("User message should contain audio input") {
+                messages[0].role shouldBe ChatCompletionRole.USER
+                val content = messages[0].content
+                content shouldBe instanceOf<MessageContent.Parts>()
+                val parts = (content as MessageContent.Parts).parts
+                parts shouldHaveSize 1
+
+                withClue("Part should be audio input") {
+                    parts[0] shouldBe instanceOf<ContentPart.InputAudio>()
+                    val audioInput = parts[0] as ContentPart.InputAudio
+                    audioInput.inputAudio.data shouldBe "BASE64_ENCODED_AUDIO"
+                    audioInput.inputAudio.format shouldBe "wav"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Should deserialize ChatCompletionRequest with reasoning effort`() {
+        val json =
+            """
+            {
+              "model": "o1",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "Solve this complex math problem: ..."
+                }
+              ],
+              "reasoning_effort": "high"
+            }
+            """.trimIndent()
+
+        val request = jsonParser.decodeFromString<ChatCompletionRequest>(json)
+
+        assertSoftly(request) {
+            model shouldBe "o1"
+            reasoningEffort shouldBe "high"
+            messages shouldHaveSize 1
+            messages[0].role shouldBe ChatCompletionRole.USER
         }
     }
 }

--- a/ai-mocks-openai/src/commonTest/kotlin/me/kpavlov/aimocks/openai/model/embeddings/EmbeddingModelsTest.kt
+++ b/ai-mocks-openai/src/commonTest/kotlin/me/kpavlov/aimocks/openai/model/embeddings/EmbeddingModelsTest.kt
@@ -10,7 +10,7 @@ internal class EmbeddingModelsTest {
     private val jsonParser =
         Json {
             ignoreUnknownKeys = true
-            prettyPrint = true
+            prettyPrint = false
         }
 
     /**

--- a/ai-mocks-openai/src/jvmTest/resources/junit-platform.properties
+++ b/ai-mocks-openai/src/jvmTest/resources/junit-platform.properties
@@ -1,4 +1,5 @@
 ## https://docs.junit.org/5.3.0-M1/user-guide/index.html#writing-tests-parallel-execution
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=concurrent


### PR DESCRIPTION
#  Support JSON schema for function parameters in chat models

Introduces SchemaHelper for JSON Schema parsing/introspection. Expands OpenAI chat models: FunctionObject.parameters now JsonElement and adds ToolChoiceSerializer. Adds new request-spec APIs and matchers for tool/function parameter assertions using SchemaHelper. Updates tests for tools, tool calls, multimodal parts, and adds JUnit parallel execution property.