### PR TITLE
Update Mokksy documentation

### DIFF
--- a/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
+++ b/ai-mocks-core/src/commonMain/kotlin/me/kpavlov/aimocks/core/AbstractMockLlm.kt
@@ -36,9 +36,9 @@ public abstract class AbstractMockLlm(
 
     /**
      * Provides the base URL of the mock server to be provided
-     * to language model client.
+     * to a language model client.
      *
      * @return The base URL as a string.
      */
-    public open fun baseUrl(): String = "http://localhost:${port()}"
+    public open fun baseUrl(): String = mokksy.baseUrl()
 }

--- a/docs/content/docs/mokksy/_index.md
+++ b/docs/content/docs/mokksy/_index.md
@@ -52,7 +52,7 @@ testImplementation("me.kpavlov.mokksy:mokksy:$latestVersion")
 ### Creating Mokksy Server
 
 ```kotlin
-// Create a Mokksy instance
+// Create and start MokksyServer instance
 val mokksy = Mokksy()
 
 // Configure a response for a GET request
@@ -62,14 +62,11 @@ mokksy.get {
   body = """{"response": "Pong"}"""
 }
 
-// Start the server
-mokksy.start()
-
 // Use the server URL in your client
-val serverUrl = mokksy.serverUrl
+val serverUrl = mokksy.baseUrl
 
-// Stop the server when done
-mokksy.stop()
+// Shutdown the server when done
+mokksy.shutdown()
 ```
 
 ## Responding with Predefined Responses
@@ -99,8 +96,8 @@ val result = client.get("/ping") {
 }
 
 // then
-assertThat(result.status).isEqualTo(HttpStatusCode.OK)
-assertThat(result.bodyAsText()).isEqualTo(expectedResponse)
+result.status shouldBe HttpStatusCode.OK
+result.bodyAsText() shouldBe expectedResponse
 ```
 
 ### POST Request

--- a/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/me/kpavlov/mokksy/MokksyServer.kt
@@ -170,6 +170,8 @@ public open class MokksyServer
          */
         public fun port(): Int = resolvedPort
 
+        public fun baseUrl(): String = "http://127.0.0.1:$resolvedPort"
+
         /**
          * Creates a request specification for the given HTTP method and request type,
          * and returns a building step for further stub configuration.
@@ -268,7 +270,9 @@ public open class MokksyServer
          *
          * Returns a `BuildingStep` for further customization of the stubbed GET request.
          */
-        public fun get(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
+        public fun get(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> =
             this.get(
                 name = null,
                 requestType = String::class,
@@ -338,8 +342,9 @@ public open class MokksyServer
          * @param block Lambda to configure the request specification builder.
          * @return A building step for further customization of the POST request stub.
          */
-        public fun post(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
-            this.post(name = null, requestType = String::class, block = block)
+        public fun post(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> = this.post(name = null, requestType = String::class, block = block)
 
         /**
          * Defines a stub for an HTTP DELETE request with the specified request type and configuration block.
@@ -384,7 +389,9 @@ public open class MokksyServer
          * @param block Lambda to configure the request specification builder.
          * @return A building step for further stub customization.
          */
-        public fun delete(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
+        public fun delete(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> =
             this.delete(name = null, requestType = String::class, block = block)
 
         /**
@@ -431,7 +438,9 @@ public open class MokksyServer
          * @param block Lambda to configure the request specification builder for the PATCH request.
          * @return A `BuildingStep` for further customization of the PATCH request stub.
          */
-        public fun patch(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
+        public fun patch(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> =
             this.patch(name = null, requestType = String::class, block = block)
 
         /**
@@ -480,8 +489,9 @@ public open class MokksyServer
          * @param block Lambda to configure the request specification builder.
          * @return A building step for further stub customization.
          */
-        public fun put(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
-            this.put(name = null, requestType = String::class, block = block)
+        public fun put(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> = this.put(name = null, requestType = String::class, block = block)
 
         /**
          * Defines a stub for an HTTP HEAD request with the specified request type and configuration block.
@@ -529,8 +539,9 @@ public open class MokksyServer
          * @param block Lambda to configure the request specification builder.
          * @return A building step for further customization of the HEAD request stub.
          */
-        public fun head(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
-            this.head(name = null, requestType = String::class, block = block)
+        public fun head(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> = this.head(name = null, requestType = String::class, block = block)
 
         /**
          * Defines a stub for an HTTP OPTIONS request with the specified request type and configuration block.
@@ -578,7 +589,9 @@ public open class MokksyServer
          * @param block Lambda to configure the request specification builder for the OPTIONS request.
          * @return A `BuildingStep` for further customization of the stub.
          */
-        public fun options(block: RequestSpecificationBuilder<String>.() -> Unit): BuildingStep<String> =
+        public fun options(
+            block: RequestSpecificationBuilder<String>.() -> Unit,
+        ): BuildingStep<String> =
             this.options(name = null, requestType = String::class, block = block)
 
         /**
@@ -635,3 +648,9 @@ public open class MokksyServer
             server.stop()
         }
     }
+
+/**
+ * A typealias for MokksyServer, allowing the use of `Mokksy`
+ * as an alternative, more concise name for referencing the `MokksyServer` class.
+ */
+public typealias Mokksy = MokksyServer

--- a/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/AbstractIT.kt
+++ b/mokksy/src/commonTest/kotlin/me/kpavlov/mokksy/AbstractIT.kt
@@ -7,8 +7,8 @@ import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
-val mokksy: MokksyServer =
-    MokksyServer(verbose = true) {
+val mokksy: Mokksy =
+    Mokksy(verbose = true) {
         it.log.info("Running Mokksy server with ${it.engine} engine")
     }
 


### PR DESCRIPTION
- Update Mokksy example to use `baseUrl` and `shutdown()` methods.
- Add `baseUrl()` API for consistent URL references.
- Introduce `Mokksy` typealias for a concise reference to `MokksyServer`.
- Refactor HTTP method stubs for improved readability with parameterized blocks.