### PR TITLE
Ensure `Content-Type` header is correctly set

### DIFF
--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinition.kt
@@ -1,6 +1,8 @@
 package dev.mokksy.mokksy.response
 
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.log
@@ -9,7 +11,6 @@ import io.ktor.server.response.ResponseHeaders
 import io.ktor.server.response.respond
 import io.ktor.util.cio.ChannelWriteException
 import kotlinx.coroutines.delay
-import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import kotlin.time.Duration
 
 /**
@@ -67,6 +68,9 @@ public open class ResponseDefinition<P, T>(
         }
         try {
             val payload: Any = effectiveBody ?: ""
+            if (call.response.headers[HttpHeaders.ContentType] == null) {
+                call.response.headers.append(HttpHeaders.ContentType, contentType.toString())
+            }
             call.respond(
                 status = httpStatus,
                 message = payload,

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/ShortcutMethodsIT.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/ShortcutMethodsIT.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RequestSpecificationBuilder
 import io.kotest.matchers.equals.beEqual
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.request
@@ -9,9 +10,9 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.http.withCharset
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import dev.mokksy.mokksy.request.RequestSpecificationBuilder
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
@@ -77,6 +78,7 @@ internal class ShortcutMethodsIT : AbstractIT() {
 
         val expectedResponseRef = AtomicReference<String>()
         val requestAsString = Json.encodeToString(requestPayload)
+        val expectedContentType = ContentType.Application.ProblemJson.withCharset(Charsets.UTF_32)
 
         block.invoke {
             configurer(this)
@@ -96,6 +98,7 @@ internal class ShortcutMethodsIT : AbstractIT() {
             }
 
             val responsePayload = TestOrder.random(person = requestPayload)
+            contentType = expectedContentType
             body = Json.encodeToString(responsePayload)
             expectedResponseRef.set(body) // safely store the response for verification
         }
@@ -111,6 +114,7 @@ internal class ShortcutMethodsIT : AbstractIT() {
 
         // then
         result.status shouldBe HttpStatusCode.OK
+        result.contentType() shouldBe expectedContentType
 
         if (method != HttpMethod.Head) {
             result.bodyAsText() shouldBe expectedResponseRef.get()


### PR DESCRIPTION
# Ensure `Content-Type` header is correctly set

A header guard was added in ResponseDefinition.writeResponse to ensure a Content-Type header is present before sending. Tests were updated to use a specific expected Content-Type with charset, assert it on responses, and adjust imports accordingly. No public API changes.