### PR TITLE
Introduce `StubRegistry` for thread-safe stub management

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 anthropic-java = "2.8.1"
 assertj = "3.27.6"
+atomicfu = "0.29.0"
 assertk = "0.28.1"
 awaitility = "4.3.0"
 datafaker = "2.5.2"
@@ -46,6 +47,7 @@ junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-para
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }
 kotlinLogging = { module = "io.github.oshai:kotlin-logging", version.ref = "kotlinLogging" }
+kotlinx-atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }
 kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
@@ -64,6 +66,7 @@ ktor-server-core = { module = "io.ktor:ktor-server-core" }
 ktor-server-double-receive = { module = "io.ktor:ktor-server-double-receive" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty" }
 ktor-server-sse = { module = "io.ktor:ktor-server-sse" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host" }
 ktor-sse = { module = "io.ktor:ktor-sse" }
 langchain4j-anthropic = { group = "dev.langchain4j", name = "langchain4j-anthropic" }
 langchain4j-bom = { group = "dev.langchain4j", name = "langchain4j-bom", version.ref = "langchain4j" }
@@ -88,6 +91,7 @@ system-stubs = { module = "uk.org.webcompere:system-stubs-jupiter", version.ref 
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
+kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
 openrewrite = { id = "org.openrewrite.rewrite", version.ref = "openrewrite" }

--- a/mokksy/build.gradle.kts
+++ b/mokksy/build.gradle.kts
@@ -1,11 +1,12 @@
 plugins {
     kotlin("plugin.serialization") apply true
-    alias(libs.plugins.kover) apply true
     `kotlin-convention`
     `dokka-convention`
     `publish-convention`
     `netty-convention`
     `shadow-convention`
+    alias(libs.plugins.kotlinx.atomicfu) apply true
+    alias(libs.plugins.kover) apply true
 }
 
 dokka {
@@ -24,6 +25,7 @@ kotlin {
                 api(libs.ktor.server.content.negotiation)
                 api(libs.ktor.server.core)
                 api(project.dependencies.platform(libs.ktor.bom))
+                implementation(libs.kotlinx.atomicfu)
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.ktor.server.double.receive)
                 implementation(libs.ktor.server.sse)
@@ -41,6 +43,7 @@ kotlin {
                 implementation(libs.mockk)
                 implementation(libs.mockk.dsl)
                 implementation(libs.kotlinLogging)
+                implementation(libs.ktor.server.test.host)
             }
         }
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/BuildingStep.kt
@@ -20,6 +20,7 @@ import kotlin.reflect.KClass
  * @property configuration Configuration options for the stub, such as name and behavior flags.
  * @property requestSpecification Specification of the request criteria that this step handles.
  * @property registerStub A callback for registering the stub with the main server or system.
+ * @author Konstantin Pavlov
  */
 public class BuildingStep<P : Any> internal constructor(
     private val requestType: KClass<P>,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/CapturedRequest.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/CapturedRequest.kt
@@ -5,26 +5,92 @@ import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.request.ContentTransformationException
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveNullable
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.reflect.KClass
-import kotlin.reflect.jvm.jvmName
 
+/**
+ * Represents an HTTP request that has been captured and provides utilities to access
+ * the request's body and its string representation.
+ *
+ * @param P The type of the request payload.
+ * @property request The raw incoming HTTP request being captured.
+ * @property type The class type of the expected request payload.
+ *
+ * The class caches the parsed body and its string representation for reuse across multiple invocations,
+ * ensuring that the body content is read and transformed only once.
+ *
+ * @author Konstantin Pavlov
+ */
 public data class CapturedRequest<P : Any>(
     val request: ApplicationRequest,
     private val type: KClass<P>,
 ) {
-    val body: P by lazy {
-        runBlocking {
-            try {
-                request.call.receive(type)
-            } catch (e: ContentTransformationException) {
-                request.call.application.log
-                    .debug("Failed to parse request body to {}", type.jvmName, e)
-                throw e
+    private val bodyCache: AtomicRef<P?> = atomic(null)
+    private val bodyStringCache: AtomicRef<String?> = atomic(null)
+
+    // Ensure only one coroutine performs the initial receive for each cache
+    private val bodyMutex: Mutex = Mutex()
+    private val bodyStringMutex: Mutex = Mutex()
+
+    val body: P
+        get() {
+            var cached = bodyCache.value
+            if (cached == null) {
+                cached =
+                    runBlocking {
+                        bodyMutex.withLock {
+                            var local: P? = bodyCache.value
+                            if (local == null) {
+                                val received =
+                                    try {
+                                        request.call.receive(type)
+                                    } catch (e: ContentTransformationException) {
+                                        request.call.application.log
+                                            .debug(
+                                                "Failed to parse request body to $type.jvmName",
+                                                e,
+                                            )
+                                        throw e
+                                    }
+                                // Atomic compareAndSet ensures only one value is set
+                                if (!bodyCache.compareAndSet(null, received)) {
+                                    // Another coroutine set it first, use their value
+                                    local = bodyCache.value
+                                } else {
+                                    local = received
+                                }
+                            }
+                            local!!
+                        }
+                    }
             }
+            return cached
         }
-    }
-    val bodyAsString: String? by lazy {
-        runBlocking { request.call.receiveNullable<String>() }
-    }
+
+    val bodyAsString: String?
+        get() {
+            var cached = bodyStringCache.value
+            if (cached == null) {
+                cached =
+                    runBlocking {
+                        bodyStringMutex.withLock {
+                            var local: String? = bodyStringCache.value
+                            if (local == null) {
+                                val received = request.call.receiveNullable<String>()
+                                if (!bodyStringCache.compareAndSet(null, received)) {
+                                    local = bodyStringCache.value
+                                } else {
+                                    local = received
+                                }
+                            }
+                            local
+                        }
+                    }
+            }
+            return cached
+        }
 }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/ServerConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/ServerConfiguration.kt
@@ -2,6 +2,22 @@ package dev.mokksy.mokksy
 
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 
+/**
+ * Represents the configuration parameters for a server.
+ *
+ * This class includes options for logging verbosity, server naming, and content negotiation
+ * setup. It allows customization of server behavior through its properties.
+ *
+ * @property verbose Determines whether detailed logging is enabled. When set to `true`,
+ *                   verbose logging is enabled for debugging purposes. Default is `false`.
+ * @property name The name of the server. Can be `null`, but defaults to "Mokksy" if not provided.
+ *                Used for identification or descriptive purposes.
+ * @property contentNegotiationConfigurer A function used to configure content negotiation for
+ *                                        the server. The provided function is invoked with
+ *                                        a `ContentNegotiationConfig` as its parameter.
+ *                                        Defaults to a platform-specific implementation.
+ * @author Konstantin Pavlov
+ */
 public data class ServerConfiguration(
     val verbose: Boolean = false,
     val name: String? = "Mokksy",

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubConfiguration.kt
@@ -1,5 +1,18 @@
 package dev.mokksy.mokksy
 
+/**
+ * Configuration class for defining the behavior and attributes of a stub.
+ *
+ * This data class is used to configure the characteristics of a stub,
+ * including its name, removal behavior, and logging verbosity.
+ *
+ * @property name The name of the stub configuration. Can be null if not provided.
+ * @property removeAfterMatch Indicates whether the stub should be automatically removed
+ *        after a successful match with a request.
+ * @property verbose Configures detailed logging for the stub, enabling or disabling
+ *        additional logging information.
+ * @author Konstantin Pavlov
+ */
 public data class StubConfiguration(
     val name: String? = null,
     val removeAfterMatch: Boolean = false,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/StubRegistry.kt
@@ -1,0 +1,138 @@
+package dev.mokksy.mokksy
+
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
+import io.ktor.server.routing.RoutingRequest
+import io.ktor.util.logging.Logger
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Thread-safe, multiplatform stub registry with atomic operations.
+ *
+ * Uses kotlinx.atomicfu for lock-free operations where possible,
+ * and kotlinx.coroutines Mutex for complex multistep operations that may suspend.
+ * @author Konstantin Pavlov
+ */
+internal class StubRegistry {
+    // Atomic reference to an immutable sorted set
+    private val stubs: AtomicRef<Set<Stub<*, *>>> = atomic(emptySet())
+
+    // Lock for operations requiring atomicity across multiple steps
+    private val mutex = Mutex()
+
+    /**
+     * Atomically adds a stub to the registry.
+     *
+     * Uses lock-free update operation that retries until successful.
+     *
+     * @throws IllegalArgumentException if stub is already registered
+     */
+    fun add(stub: Stub<*, *>) {
+        stubs.update { currentSet ->
+            require(stub !in currentSet) { "Duplicate stub detected: ${stub.toLogString()}" }
+            (currentSet + stub).toSortedSet(StubComparator)
+        }
+    }
+
+    /**
+     * Atomically finds and optionally removes the best matching stub.
+     *
+     * This operation is atomic to prevent TOCTOU race conditions:
+     * - Match and remove happen in a single critical section
+     * - Match count is incremented atomically
+     * - No other thread can interfere between match and remove
+     *
+     * @param request The incoming HTTP request to match
+     * @return The matched stub, or null if no match found
+     */
+    suspend fun findMatchingStub(
+        request: RoutingRequest,
+        verbose: Boolean,
+        logger: Logger,
+        formatter: HttpFormatter,
+    ): Stub<*, *>? =
+        mutex.withLock {
+            val currentSet = stubs.value
+
+            // Find best match using priority and creation order
+            val match =
+                currentSet
+                    .filter { stub ->
+                        stub.requestSpecification
+                            .matches(request)
+                            .onFailure {
+                                if (verbose) {
+                                    logger.warn(
+                                        "Failed to evaluate condition for stub:\n---\n${
+                                            stub.toLogString()
+                                        }\n---" +
+                                            "\nand request:\n---\n${
+                                                formatter.formatRequest(request)
+                                            }---",
+                                        it,
+                                    )
+                                }
+                            }.getOrNull() == true
+                    }.minWithOrNull(StubComparator)
+
+            if (match != null) {
+                // Atomically increment match count
+                match.incrementMatchCount()
+
+                // Atomically remove if configured
+                if (match.configuration.removeAfterMatch) {
+                    stubs.update { (currentSet - match).toSortedSet(StubComparator) }
+                    if (verbose) {
+                        logger.debug(
+                            "Removed used stub: ${match.toLogString()}",
+                        )
+                    }
+                }
+            }
+
+            match
+        }
+
+    /**
+     * Atomically removes a specific stub.
+     *
+     * @return true if stub was removed, false if it wasn't present
+     */
+    fun remove(stub: Stub<*, *>): Boolean {
+        var removed = false
+        stubs.update { currentSet ->
+            removed = stub in currentSet
+            currentSet - stub
+        }
+        return removed
+    }
+
+    /**
+     * Returns a snapshot of all registered stubs.
+     *
+     * This is a consistent snapshot at a point in time.
+     */
+    fun getAll(): Set<Stub<*, *>> = stubs.value
+}
+
+/**
+ * Atomic update operation that retries until successful.
+ *
+ * This is a lock-free operation that:
+ * 1. Reads current value
+ * 2. Computes new value
+ * 3. Attempts compareAndSet
+ * 4. Retries if another thread modified the value
+ */
+private inline fun <T> AtomicRef<T>.update(function: (T) -> T) {
+    while (true) {
+        val current = value
+        val updated = function(current)
+        if (compareAndSet(current, updated)) {
+            return
+        }
+        // Another thread modified the value, retry
+    }
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/AbstractResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/AbstractResponseDefinition.kt
@@ -9,6 +9,7 @@ import kotlin.time.Duration
 internal typealias ResponseDefinitionSupplier<T> = (
     ApplicationCall,
 ) -> AbstractResponseDefinition<T>
+
 /**
  * Represents the base definition of an HTTP response in a mapping between a request and its corresponding response.
  * Provides the required attributes and behavior for configuring HTTP responses, including status code, headers,
@@ -22,7 +23,9 @@ internal typealias ResponseDefinitionSupplier<T> = (
  * @property headerList A list of header key-value pairs to populate the response headers. Defaults to an empty list.
  * @property delay A delay applied before sending the response. Defaults to [Duration.ZERO].
  * @property responseBody The optional response payload associated with this definition.
+ * @author Konstantin Pavlov
  */
+@Suppress("LongParameterList")
 public abstract class AbstractResponseDefinition<T>(
     public val contentType: ContentType,
     public val httpStatusCode: Int = 200,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinition.kt
@@ -29,6 +29,7 @@ import kotlin.time.Duration
  * @property delay Delay before the response is sent. The default value is zero.
  * @property formatter A utility class to format HTTP requests and responses into colorized strings
  * for better readability.
+ * @author Konstantin Pavlov
  */
 @Suppress("LongParameterList")
 public open class ResponseDefinition<P, T>(

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
@@ -1,11 +1,11 @@
 package dev.mokksy.mokksy.response
 
+import dev.mokksy.mokksy.CapturedRequest
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.ResponseHeaders
 import kotlinx.coroutines.flow.Flow
-import dev.mokksy.mokksy.CapturedRequest
-import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -18,6 +18,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * @param T The type of the response data, which is returned to the client.
  * @property httpStatus The HTTP status code to be associated with the response.
  * @property headers A mutable list of header key-value pairs to be included in the response.
+ * @author Konstantin Pavlov
  */
 public abstract class AbstractResponseDefinitionBuilder<P, T>(
     public var httpStatusCode: Int = 200,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/SseStreamResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/SseStreamResponseDefinition.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy.response
 
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.ApplicationCall
@@ -14,9 +15,22 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
-import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import kotlin.time.Duration
 
+/**
+ * Represents a response definition for server-sent events (SSE) streaming.
+ *
+ * This class extends [StreamResponseDefinition] and is used to configure and handle an SSE response.
+ * It provides functionality for sending a stream of SSE events to the client, utilizing a specified
+ * [chunkFlow] and configuring response metadata.
+ *
+ * @param P The payload type for the SSE events.
+ * @param chunkFlow A [Flow] of [ServerSentEvent] representing the stream of SSE events. Defaults to `null`.
+ * @param chunkContentType The [ContentType] for the chunks in the SSE stream. Defaults to `null`.
+ * @param delay An optional delay between chunks, specified as a [Duration]. Defaults to `Duration.ZERO`.
+ * @param formatter An [HttpFormatter] responsible for formatting the HTTP response or payloads.
+ * @author Konstantin Pavlov
+ */
 public open class SseStreamResponseDefinition<P>(
     override val chunkFlow: Flow<ServerSentEvent>? = null,
     chunkContentType: ContentType? = null,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/StreamResponseDefinition.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/StreamResponseDefinition.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy.response
 
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.CacheControl
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -22,7 +23,6 @@ import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.yield
-import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import kotlin.time.Duration
 
 internal const val SEND_BUFFER_CAPACITY = 256
@@ -43,8 +43,9 @@ internal const val SEND_BUFFER_CAPACITY = 256
  * @constructor Initializes a streaming response definition with the specified flow, chunk list, content type,
  *              HTTP status code, and headers.
  *
- * Extends:
  * @see AbstractResponseDefinition
+ *
+ * @author Konstantin Pavlov
  */
 @Suppress("LongParameterList")
 public open class StreamResponseDefinition<P, T>(

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/serializers/StringOrListSerializer.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/serializers/StringOrListSerializer.kt
@@ -12,6 +12,33 @@ import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
+/**
+ * A custom serializer for handling JSON values that can either be a single string
+ * or a list of strings. This serializer ensures that both formats are correctly
+ * deserialized into a `List<String>` and serialized back into their appropriate
+ * JSON representation.
+ *
+ * This is particularly useful in cases where a JSON API may respond with a single
+ * string if there is only one value, or a list of strings if there are multiple values.
+ *
+ * This serializer's behavior:
+ * - During deserialization:
+ *   - If the value is a string, it converts it into a single-element list.
+ *   - If the value is an array of strings, it converts it into a list of strings.
+ * - During serialization:
+ *   - If the list contains exactly one element, it serializes it as a single string.
+ *   - If the list size is not equal to 1 (including empty lists), it serializes it as a JSON array.
+ *     Empty lists become empty JSON arrays [].
+ *
+ * This serializer is compatible only with JSON encoding and decoding.
+ *
+ * Throws:
+ * - `SerializationException` if the serializer is used with a format other than JSON.
+ * - `SerializationException` if the input during deserialization is neither a string
+ *   nor an array of strings.
+ *
+ * @author Konstantin Pavlov
+ */
 public class StringOrListSerializer : KSerializer<List<String>> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("StringOrList")
 

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/Base64Urls.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/utils/Base64Urls.kt
@@ -27,5 +27,6 @@ public fun ByteArray.asBase64DataUrl(mimeType: MimeType): String {
  * @see [data: URLs](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data)
  */
 @JvmOverloads
-public fun URL.asBase64DataUrl(mimeType: MimeType = ContentType.defaultForFilePath(this.path).asMimeType()): String =
-    readBytes().asBase64DataUrl(mimeType)
+public fun URL.asBase64DataUrl(
+    mimeType: MimeType = ContentType.defaultForFilePath(this.path).asMimeType(),
+): String = readBytes().asBase64DataUrl(mimeType)

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/BuildingStepTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/BuildingStepTest.kt
@@ -1,5 +1,7 @@
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RequestSpecification
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -8,8 +10,6 @@ import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import dev.mokksy.mokksy.request.RequestSpecification
-import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/RequestSpecificationTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/RequestSpecificationTest.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RequestSpecification
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.equals.beEqual
 import io.kotest.matchers.shouldBe
@@ -18,7 +19,6 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import dev.mokksy.mokksy.request.RequestSpecification
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/CapturedRequestTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/CapturedRequestTest.kt
@@ -1,0 +1,95 @@
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.CapturedRequest
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.server.response.respondText
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import io.ktor.server.routing.post as serverPost
+
+internal class CapturedRequestTest {
+    @Test
+    fun `should cache typed body under concurrent access`() =
+        runTest {
+            val raw = "concurrent-body-text"
+
+            testApplication {
+                routing {
+                    serverPost("/body") {
+                        val captured = CapturedRequest(call.request, String::class)
+
+                        val first = captured.body
+
+                        val allSame =
+                            coroutineScope {
+                                val results = (1..25).map { async { captured.body } }.awaitAll()
+                                results.all { it == first }
+                            }
+
+                        call.respondText("$first|$allSame")
+                    }
+                }
+
+                val response =
+                    client.post("/body") {
+                        contentType(ContentType.Text.Plain)
+                        setBody(raw)
+                    }
+
+                val payload = response.bodyAsText()
+                val parts = payload.split("|")
+
+                // First part is the returned body, second part is the allSame flag
+                parts[0] shouldBe raw
+                parts[1] shouldBe "true"
+            }
+        }
+
+    @Test
+    fun `should cache bodyAsString under concurrent access`() =
+        runTest {
+            val raw = "concurrent-body-string"
+
+            testApplication {
+                routing {
+                    serverPost("/bodyString") {
+                        val captured = CapturedRequest(call.request, String::class)
+
+                        val first = captured.bodyAsString
+
+                        val allSame =
+                            coroutineScope {
+                                val results =
+                                    (1..25)
+                                        .map { async { captured.bodyAsString } }
+                                        .awaitAll()
+                                results.all { it == first }
+                            }
+
+                        call.respondText("${first ?: ""}|$allSame")
+                    }
+                }
+
+                val response =
+                    client.post("/bodyString") {
+                        contentType(ContentType.Text.Plain)
+                        setBody(raw)
+                    }
+
+                val payload = response.bodyAsText()
+                val parts = payload.split("|")
+
+                parts[0] shouldBe raw
+                parts[1] shouldBe "true"
+            }
+        }
+}

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/RequestMarchersKtTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/RequestMarchersKtTest.kt
@@ -1,10 +1,10 @@
 package dev.mokksy.mokksy.request
 
+import dev.mokksy.mokksy.Input
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
-import dev.mokksy.mokksy.Input
 import org.junit.jupiter.api.Test
 
 class RequestMarchersKtTest {

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubComparatorTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubComparatorTest.kt
@@ -4,10 +4,10 @@ import assertk.assertThat
 import assertk.assertions.isNegative
 import assertk.assertions.isPositive
 import assertk.assertions.isZero
-import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.MockKExtension
 import dev.mokksy.mokksy.request.RequestSpecification
 import dev.mokksy.mokksy.response.ResponseDefinitionSupplier
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubRegistryTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/StubRegistryTest.kt
@@ -1,0 +1,211 @@
+package dev.mokksy.mokksy
+
+import dev.mokksy.mokksy.request.RequestSpecification
+import dev.mokksy.mokksy.response.AbstractResponseDefinition
+import dev.mokksy.mokksy.utils.logger.HttpFormatter
+import io.kotest.matchers.shouldBe
+import io.ktor.http.ContentType
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.routing.RoutingRequest
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+@ExtendWith(MockKExtension::class)
+class StubRegistryTest {
+    private fun <T : Any> responseSupplier(): (
+        ApplicationCall,
+    ) -> AbstractResponseDefinition<T> =
+        { _ ->
+            object : AbstractResponseDefinition<T>(
+                contentType = ContentType.Any,
+                httpStatusCode = 200,
+            ) {
+                override suspend fun writeResponse(
+                    call: ApplicationCall,
+                    verbose: Boolean,
+                ) {
+                    // no-op for tests
+                }
+            }
+        }
+
+    private fun <P : Any, T : Any> stub(
+        name: String? = null,
+        priority: Int? = null,
+        removeAfterMatch: Boolean = false,
+        requestType: KClass<P>,
+    ): Stub<P, T> {
+        val spec =
+            RequestSpecification(
+                // leave all matchers null/empty so it matches any request without touching it
+                requestType = requestType,
+                priority = priority,
+            )
+        return Stub(
+            configuration = StubConfiguration(name = name, removeAfterMatch = removeAfterMatch),
+            requestSpecification = spec,
+            responseDefinitionSupplier = responseSupplier(),
+        )
+    }
+
+    @MockK
+    lateinit var routingRequest: RoutingRequest
+
+    @Nested
+    inner class AddAndGetAll {
+        @Test
+        fun `should add stubs and return sorted snapshot`() =
+            runTest {
+                val registry = StubRegistry()
+
+                val s1 =
+                    stub<String, String>(name = "s1", priority = 10, requestType = String::class)
+                val s2 =
+                    stub<String, String>(name = "s2", priority = 1, requestType = String::class)
+                val s3 =
+                    stub<String, String>(name = "s3", priority = 10, requestType = String::class)
+
+                registry.add(s1)
+                registry.add(s2)
+                registry.add(s3)
+
+                val all = registry.getAll().toList()
+
+                // Expect ordering by priority asc, then creation order
+                all shouldBe listOf(s2, s1, s3)
+            }
+
+        @Test
+        fun `should throw on duplicate stub`() =
+            runTest {
+                val registry = StubRegistry()
+                val s1 =
+                    stub<String, String>(name = "dup", priority = 5, requestType = String::class)
+
+                registry.add(s1)
+
+                assertFailsWith<IllegalArgumentException> {
+                    registry.add(s1)
+                }
+            }
+    }
+
+    @Nested
+    inner class FindMatchingStub {
+        @Test
+        fun `should return best match by priority and increment matchCount`() =
+            runTest {
+                val registry = StubRegistry()
+                val lowPrio =
+                    stub<String, String>(name = "low", priority = 100, requestType = String::class)
+                val highPrio =
+                    stub<String, String>(name = "high", priority = 1, requestType = String::class)
+
+                registry.add(lowPrio)
+                registry.add(highPrio)
+
+                val matched =
+                    registry.findMatchingStub(
+                        request = routingRequest,
+                        verbose = false,
+                        logger = mockk(relaxed = true),
+                        formatter =
+                            HttpFormatter(),
+                    )
+
+                matched shouldBe highPrio
+                highPrio.matchCount() shouldBe 1
+                lowPrio.matchCount() shouldBe 0
+            }
+
+        @Test
+        fun `should break ties by creation order`() =
+            runTest {
+                val registry = StubRegistry()
+                val first =
+                    stub<String, String>(name = "first", priority = 10, requestType = String::class)
+                val second =
+                    stub<String, String>(
+                        name = "second",
+                        priority = 10,
+                        requestType = String::class,
+                    )
+
+                registry.add(first)
+                registry.add(second)
+
+                val matched =
+                    registry.findMatchingStub(
+                        request = routingRequest,
+                        verbose = false,
+                        logger = mockk(relaxed = true),
+                        formatter =
+                            HttpFormatter(),
+                    )
+
+                matched shouldBe first
+            }
+
+        @Test
+        fun `should remove stub after match when configured`() =
+            runTest {
+                val registry = StubRegistry()
+                val removable =
+                    stub<String, String>(
+                        name = "once",
+                        priority = 5,
+                        removeAfterMatch = true,
+                        requestType = String::class,
+                    )
+
+                registry.add(removable)
+
+                val matched1 =
+                    registry.findMatchingStub(
+                        request = routingRequest,
+                        verbose = false,
+                        logger = mockk(relaxed = true),
+                        formatter =
+                            HttpFormatter(),
+                    )
+                matched1 shouldBe removable
+                removable.matchCount() shouldBe 1
+
+                // Next time it should not be present
+                val matched2 =
+                    registry.findMatchingStub(
+                        request = routingRequest,
+                        verbose = false,
+                        logger = mockk(relaxed = true),
+                        formatter =
+                            HttpFormatter(),
+                    )
+                matched2 shouldBe null
+                registry.getAll().isEmpty() shouldBe true
+            }
+    }
+
+    @Nested
+    inner class RemoveSpecificStub {
+        @Test
+        fun `should remove stub and report status`() =
+            runTest {
+                val registry = StubRegistry()
+                val s = stub<String, String>(name = "s", priority = 7, requestType = String::class)
+
+                // not present yet
+                registry.remove(s) shouldBe false
+
+                registry.add(s)
+                registry.remove(s) shouldBe true
+                registry.remove(s) shouldBe false
+            }
+    }
+}


### PR DESCRIPTION
# Introduce `StubRegistry` for thread-safe stub management

- Added a multiplatform `StubRegistry` to centralize and manage stub operations using `kotlinx.atomicfu` for atomic updates and thread safety.
- Replaced `ConcurrentSkipListSet` with `StubRegistry` in `MokksyServer` and `RequestHandler` for improved atomicity and locking.
- Updated `CapturedRequest` to cache `body` and `bodyAsString` atomically for better performance in concurrent scenarios.
- Refactored atomic counters in `Stub` to use `atomicfu` for multiplatform compatibility.
- Added comprehensive tests for `StubRegistry`.
- Upgraded the build to include `kotlinx.atomicfu` dependency.

No changes to the public API, but this improves internal thread safety and consistency for stub management.