### PR TITLE
chore(build): Integrate Detekt with updated plugin and configuration

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,7 +59,7 @@ jobs:
           ./gradlew \
             --rerun-tasks --no-daemon \
             -Dorg.gradle.maven.repo.local=.m2-local \
-            clean build publishToMavenLocal koverXmlReport
+            clean build detekt publishToMavenLocal koverXmlReport
 
       - name: OpenAI Maven Integration Tests
         working-directory: ai-mocks-openai/samples/shadow

--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DetektPluginSettings">
+    <option name="configurationFiles">
+      <list>
+        <option value="$PROJECT_DIR$/detekt.yml" />
+      </list>
+    </option>
     <option name="enableDetekt" value="true" />
     <option name="enableForProjectResult" value="Accepted" />
+    <option name="enableFormatting" value="true" />
+    <option name="treatAsErrors" value="true" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,17 @@ allprojects {
 
 // Common configuration for subprojects
 subprojects {
-    apply(plugin = "org.jetbrains.dokka")
-    apply(plugin = "org.jetbrains.dokka-javadoc")
-    apply(plugin = "com.diffplug.spotless")
+    apply {
+        plugin("org.jetbrains.dokka")
+        plugin("org.jetbrains.dokka-javadoc")
+        plugin("com.diffplug.spotless")
+        plugin("dev.detekt")
+    }
+
+    detekt {
+        config = files("$rootDir/detekt.yml")
+        buildUponDefaultConfig = true
+    }
 }
 
 dependencies {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "buildSrc"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
@@ -79,3 +79,7 @@ tasks.withType<Test>().configureEach {
         junitXml.includeSystemErrLog.set(true)
     }
 }
+
+tasks.named("detekt").configure {
+    dependsOn("detektMainJvm", "detektTestJvm")
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,8 +1,3 @@
-style:
-  active: true
-  MethodName:
-    active: true
-    ignoreOverriddenFunctions: true
-    excludeAnnotatedMethodsOrClasses:
-      - "org.junit.jupiter.api.Test"
-    ignoreTestFiles: true
+config:
+  validation: true
+  warningsAsErrors: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ atomicfu = "0.29.0"
 assertk = "0.28.1"
 awaitility = "4.3.0"
 datafaker = "2.5.3"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.1"
 dokka = "2.1.0"
 finchly = "0.1.1"
 google-genai = "1.34.0"
@@ -90,7 +90,7 @@ spring-bom = { group = "org.springframework", name = "spring-framework-bom", ver
 system-stubs = { module = "uk.org.webcompere:system-stubs-jupiter", version.ref = "system-stubs" }
 
 [plugins]
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "ai-mocks"
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include(
     ":a2a-client",
     ":ai-mocks-a2a",


### PR DESCRIPTION
- Migrated to `dev.detekt` plugin version `2.0.0-alpha.1`.
- Added Detekt configuration to `build.gradle.kts` with default config and custom rules.
- Updated CI workflow to include `detekt` in the build process.
- Enabled `TYPESAFE_PROJECT_ACCESSORS` feature previews.
- Linked `detekt` task dependencies for improved build task execution.