### PR TITLE
feat(mokksy): Add request journaling to track unmatched requests

### DIFF
--- a/docs/content/docs/mokksy/_index.md
+++ b/docs/content/docs/mokksy/_index.md
@@ -220,30 +220,95 @@ assertThat(result.bodyAsText())
 
 ## Verifying Requests
 
-After your test is complete, you can verify that all expected requests were received:
+Mokksy provides two complementary verification methods that check opposite sides of the stub/request contract.
+
+### Verify all stubs were triggered
+
+`checkForUnmatchedStubs()` fails if any registered stub was never matched by an incoming request. Use this to catch
+stubs you set up but that were never actually called — a sign the code under test took a different path than expected.
 
 ```kotlin
-// Verify no unmatched requests
+// Fails if any stub has matchCount == 0
+mokksy.checkForUnmatchedStubs()
+```
+
+### Verify no unexpected requests arrived
+
+`checkForUnmatchedRequests()` fails if any HTTP request arrived at the server but no stub matched it. These requests are
+recorded in the [request journal](#request-journal) and reported together.
+
+```kotlin
+// Fails if any request arrived with no matching stub (unexpected request)
 mokksy.checkForUnmatchedRequests()
 ```
 
-If there is an unexpected request to the mock, then AssertionError will be thrown.
+### Recommended AfterEach setup
 
-It's a good practice to run it after every test:
+Run both checks after every test to catch mismatch in either direction:
 
 ```kotlin
 class MyTest {
-    
+
     private val mokksy = Mokksy()
-  
+
     @AfterEach
     fun afterEach() {
-      mokksy.checkForUnmatchedRequests()
+      mokksy.checkForUnmatchedRequests() // no unexpected HTTP calls
+      mokksy.checkForUnmatchedStubs()    // no unused stubs
     }
-  
-    @Test
+
+  @Test
     fun testSomething() {
         TODO("Write your test here")
     }
+}
+```
+
+### Inspecting unmatched items
+
+Use the `find*` variants to retrieve the unmatched items directly for custom assertions:
+
+```kotlin
+// List<RecordedRequest> — HTTP requests with no matching stub
+val unmatchedRequests: List<RecordedRequest> = mokksy.findAllUnmatchedRequests()
+
+// List<RequestSpecification<*>> — stubs that were never triggered
+val unmatchedStubs: List<RequestSpecification<*>> = mokksy.findAllUnmatchedStubs()
+```
+
+`RecordedRequest` is an immutable snapshot that captures the `method`, `uri`, and `headers` of the incoming request.
+
+## Request Journal
+
+Mokksy records incoming requests in a `RequestJournal`. The recording mode is controlled by `JournalMode` in
+`ServerConfiguration`:
+
+| Mode                           | Behaviour                                                                                                  |
+|--------------------------------|------------------------------------------------------------------------------------------------------------|
+| `JournalMode.LEAN` *(default)* | Records only requests with no matching stub. Lower overhead. Sufficient for `checkForUnmatchedRequests()`. |
+| `JournalMode.FULL`             | Records all incoming requests — both matched and unmatched.                                                |
+
+```kotlin
+val mokksy = Mokksy(
+  configuration = ServerConfiguration(
+    journalMode = JournalMode.FULL
+  )
+)
+```
+
+Use `FULL` mode when you need a complete picture of traffic, for example to debug unexpected call patterns by combining
+both lists:
+
+```kotlin
+val unmatched = mokksy.findAllUnmatchedRequests()
+// unmatched is empty only if every request found a matching stub
+```
+
+Call `resetMatchCounts()` between tests to clear both stub match counts and the journal:
+
+```kotlin
+@AfterEach
+fun afterEach() {
+  mokksy.resetMatchCounts()
 }
 ```

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/BuildingStep.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/BuildingStep.kt
@@ -1,5 +1,6 @@
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.CapturedRequest
 import dev.mokksy.mokksy.request.RequestSpecification
 import dev.mokksy.mokksy.response.ResponseDefinitionBuilder
 import dev.mokksy.mokksy.response.StreamingResponseDefinitionBuilder

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/MokksyServer.kt
@@ -1,5 +1,7 @@
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RecordedRequest
+import dev.mokksy.mokksy.request.RequestJournal
 import dev.mokksy.mokksy.request.RequestSpecification
 import dev.mokksy.mokksy.request.RequestSpecificationBuilder
 import dev.mokksy.mokksy.request.methodEqual
@@ -124,6 +126,7 @@ public open class MokksyServer
         protected val httpFormatter: HttpFormatter = HttpFormatter()
 
         private val stubRegistry = StubRegistry()
+        private val requestJournal = RequestJournal(configuration.journalMode)
 
         private val server =
             createEmbeddedServer(
@@ -146,6 +149,7 @@ public open class MokksyServer
                                 context = this@handle,
                                 application = this@createEmbeddedServer,
                                 stubRegistry = stubRegistry,
+                                requestJournal = requestJournal,
                                 configuration = configuration,
                                 formatter = httpFormatter,
                             )
@@ -609,13 +613,13 @@ public open class MokksyServer
             this.options(name = null, requestType = String::class, block = block)
 
         /**
-         * Returns all request specifications that have not matched any incoming requests.
+         * Returns all stub specifications that have not been matched by any incoming request.
          *
-         * A request specification is considered unmatched if its associated stub's match count is zero.
+         * A stub is considered unmatched if its match count is zero.
          *
-         * @return A list of unmatched request specifications.
+         * @return A list of unmatched stub request specifications.
          */
-        public fun findAllUnmatchedRequests(): List<RequestSpecification<*>> =
+        public fun findAllUnmatchedStubs(): List<RequestSpecification<*>> =
             stubRegistry
                 .getAll()
                 .filter {
@@ -624,7 +628,14 @@ public open class MokksyServer
                 .toList()
 
         /**
-         * Resets the match count of all registered stubs to zero.
+         * Returns all HTTP requests that arrived at the server but were not matched by any stub.
+         *
+         * @return A list of [RecordedRequest] snapshots.
+         */
+        public fun findAllUnmatchedRequests(): List<RecordedRequest> = requestJournal.getUnmatched()
+
+        /**
+         * Resets the match count of all registered stubs to zero and clears the request journal.
          *
          * Use this to clear match history before running new tests or scenarios.
          */
@@ -634,23 +645,36 @@ public open class MokksyServer
                 .forEach {
                     it.resetMatchCount()
                 }
+            requestJournal.clear()
         }
 
         /**
-         * Verifies that all registered request stubs have been matched at least once.
+         * Verifies that all registered stubs have been matched at least once.
          *
-         * Throws an error if any request specification was not triggered during execution,
-         * listing all unmatched requests.
+         * Throws an error if any stub was registered but never triggered during execution.
+         */
+        public fun checkForUnmatchedStubs() {
+            val unmatchedStubs = findAllUnmatchedStubs()
+            if (unmatchedStubs.isNotEmpty()) {
+                failure(
+                    "The following stubs were not matched: ${
+                        unmatchedStubs.joinToString { it.toLogString() }
+                    }",
+                )
+            }
+        }
+
+        /**
+         * Verifies that all incoming HTTP requests were matched by a registered stub.
+         *
+         * Throws an error if any request arrived with no matching stub, listing all such requests.
          */
         public fun checkForUnmatchedRequests() {
-            val unmatchedRequests = findAllUnmatchedRequests()
-            if (unmatchedRequests.isNotEmpty()) {
+            val unmatched = findAllUnmatchedRequests()
+            if (unmatched.isNotEmpty()) {
                 failure(
-                    "The following requests were not matched: ${
-                        unmatchedRequests.joinToString {
-                            it
-                                .toLogString()
-                        }
+                    "The following requests were not matched by any stub: ${
+                        unmatched.joinToString()
                     }",
                 )
             }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/RequestHandler.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/RequestHandler.kt
@@ -1,5 +1,7 @@
 package dev.mokksy.mokksy
 
+import dev.mokksy.mokksy.request.RecordedRequest
+import dev.mokksy.mokksy.request.RequestJournal
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.kotest.assertions.failure
 import io.ktor.server.application.Application
@@ -21,10 +23,12 @@ import io.ktor.server.routing.RoutingRequest
  * @param formatter Formats HTTP requests for logging and error messages.
  * @author Konstantin Pavlov
  */
+@Suppress("LongParameterList")
 internal suspend fun handleRequest(
     context: RoutingContext,
     application: Application,
     stubRegistry: StubRegistry,
+    requestJournal: RequestJournal,
     configuration: ServerConfiguration,
     formatter: HttpFormatter,
 ) {
@@ -38,7 +42,10 @@ internal suspend fun handleRequest(
             formatter = formatter,
         )
 
+    val recorded = RecordedRequest.from(request)
+
     if (matchedStub != null) {
+        requestJournal.recordMatched(recorded)
         handleMatchedStub(
             matchedStub = matchedStub,
             serverConfig = configuration,
@@ -48,6 +55,7 @@ internal suspend fun handleRequest(
             formatter = formatter,
         )
     } else {
+        requestJournal.recordUnmatched(recorded)
         if (configuration.verbose) {
             val stubsInfo = stubRegistry.getAll().joinToString("\n---\n") { it.toLogString() }
             application.log.warn(

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/ServerConfiguration.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/ServerConfiguration.kt
@@ -3,6 +3,23 @@ package dev.mokksy.mokksy
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 
 /**
+ * Controls which requests are recorded in the [RequestJournal].
+ */
+public enum class JournalMode {
+    /**
+     * Records only requests with no matching stub.
+     * Lower overhead; sufficient for [MokksyServer.checkForUnmatchedRequests].
+     */
+    LEAN,
+
+    /**
+     * Records all incoming requests, differentiating matched from unmatched.
+     * Enables inspection of both [MokksyServer.findAllUnmatchedRequests] and matched requests.
+     */
+    FULL,
+}
+
+/**
  * Represents the configuration parameters for a server.
  *
  * This class includes options for logging verbosity, server naming, and content negotiation
@@ -12,6 +29,8 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
  *                   verbose logging is enabled for debugging purposes. Default is `false`.
  * @property name The name of the server. Can be `null`, but defaults to "Mokksy" if not provided.
  *                Used for identification or descriptive purposes.
+ * @property journalMode Controls which requests are recorded in the [RequestJournal].
+ *                       Defaults to [JournalMode.LEAN] (only unmatched requests).
  * @property contentNegotiationConfigurer A function used to configure content negotiation for
  *                                        the server. The provided function is invoked with
  *                                        a `ContentNegotiationConfig` as its parameter.
@@ -21,6 +40,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig
 public data class ServerConfiguration(
     val verbose: Boolean = false,
     val name: String? = "Mokksy",
+    val journalMode: JournalMode = JournalMode.LEAN,
     val contentNegotiationConfigurer: (
         ContentNegotiationConfig,
     ) -> Unit = ::configureContentNegotiation,

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/CapturedRequest.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/CapturedRequest.kt
@@ -1,4 +1,4 @@
-package dev.mokksy.mokksy
+package dev.mokksy.mokksy.request
 
 import io.ktor.server.application.log
 import io.ktor.server.request.ApplicationRequest
@@ -82,11 +82,16 @@ public data class CapturedRequest<P : Any>(
                             var local: String? = bodyStringCache.value
                             if (local == null) {
                                 val received = request.call.receiveNullable<String>()
-                                if (!bodyStringCache.compareAndSet(null, received)) {
-                                    local = bodyStringCache.value
-                                } else {
-                                    local = received
-                                }
+                                local =
+                                    if (!bodyStringCache.compareAndSet(
+                                            expect = null,
+                                            update = received,
+                                        )
+                                    ) {
+                                        bodyStringCache.value
+                                    } else {
+                                        received
+                                    }
                             }
                             local
                         }

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RecordedRequest.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RecordedRequest.kt
@@ -1,0 +1,35 @@
+package dev.mokksy.mokksy.request
+
+import io.ktor.http.HttpMethod
+import io.ktor.server.routing.RoutingRequest
+
+/**
+ * Immutable snapshot of an HTTP request for recording purposes.
+ *
+ * Unlike [CapturedRequest], this class does not retain references to
+ * the underlying request or connection, making it safe for long-term storage
+ * (e.g., tracking requests that arrived with no matching stub).
+ *
+ * @property method The HTTP method of the request.
+ * @property uri The URI of the request.
+ * @property headers The headers of the request.
+ */
+public data class RecordedRequest(
+    val method: HttpMethod,
+    val uri: String,
+    val headers: Map<String, List<String>>,
+) {
+    public companion object {
+        /**
+         * Creates a [RecordedRequest] snapshot from a [io.ktor.server.routing.RoutingRequest].
+         */
+        public fun from(request: RoutingRequest): RecordedRequest =
+            RecordedRequest(
+                method = request.local.method,
+                uri = request.local.uri,
+                headers = request.headers.entries().associate { it.key to it.value },
+            )
+    }
+
+    override fun toString(): String = "${method.value} $uri"
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestJournal.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/request/RequestJournal.kt
@@ -1,0 +1,56 @@
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.JournalMode
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * Records [RecordedRequest] snapshots for post-test verification,
+ * differentiating between requests matched by a stub and those that were not.
+ *
+ * Recording behaviour is controlled by [JournalMode]:
+ * - [dev.mokksy.mokksy.JournalMode.LEAN]: only unmatched requests are recorded (lower overhead).
+ * - [dev.mokksy.mokksy.JournalMode.FULL]: all requests are recorded, matched and unmatched alike.
+ *
+ * All operations are thread-safe and lock-free.
+ * @author Konstantin Pavlov
+ */
+internal class RequestJournal(
+    private val mode: JournalMode = JournalMode.LEAN,
+) {
+    private val matched: AtomicRef<PersistentList<RecordedRequest>> = atomic(persistentListOf())
+    private val unmatched: AtomicRef<PersistentList<RecordedRequest>> = atomic(persistentListOf())
+
+    /**
+     * Records a request that was successfully matched by a stub.
+     * No-op in [JournalMode.LEAN].
+     */
+    fun recordMatched(request: RecordedRequest) {
+        if (mode == JournalMode.FULL) {
+            matched.update { it.add(request) }
+        }
+    }
+
+    /** Records a request for which no stub was found. */
+    fun recordUnmatched(request: RecordedRequest) {
+        unmatched.update { it.add(request) }
+    }
+
+    /**
+     * Returns a consistent snapshot of all requests matched by a stub.
+     * Always empty in [JournalMode.LEAN].
+     */
+    fun getMatched(): List<RecordedRequest> = matched.value
+
+    /** Returns a consistent snapshot of all requests that had no matching stub. */
+    fun getUnmatched(): List<RecordedRequest> = unmatched.value
+
+    /** Clears both matched and unmatched request histories. */
+    fun clear() {
+        matched.value = persistentListOf()
+        unmatched.value = persistentListOf()
+    }
+}

--- a/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
+++ b/mokksy/src/commonMain/kotlin/dev/mokksy/mokksy/response/ResponseDefinitionBuilders.kt
@@ -1,6 +1,6 @@
 package dev.mokksy.mokksy.response
 
-import dev.mokksy.mokksy.CapturedRequest
+import dev.mokksy.mokksy.request.CapturedRequest
 import dev.mokksy.mokksy.utils.logger.HttpFormatter
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/AbstractIT.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/AbstractIT.kt
@@ -36,5 +36,6 @@ internal abstract class AbstractIT(
     @AfterTest
     fun afterEach() {
         mokksy.checkForUnmatchedRequests()
+        mokksy.checkForUnmatchedStubs()
     }
 }

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/CapturedRequestTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/CapturedRequestTest.kt
@@ -1,6 +1,5 @@
 package dev.mokksy.mokksy.request
 
-import dev.mokksy.mokksy.CapturedRequest
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody

--- a/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/RequestJournalTest.kt
+++ b/mokksy/src/commonTest/kotlin/dev/mokksy/mokksy/request/RequestJournalTest.kt
@@ -1,0 +1,56 @@
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.JournalMode
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpMethod
+import kotlin.test.Test
+
+internal class RequestJournalTest {
+    private val request1 = RecordedRequest(HttpMethod.Get, "/test1", emptyMap())
+    private val request2 =
+        RecordedRequest(
+            HttpMethod.Post,
+            "/test2",
+            mapOf("Content-Type" to listOf("application/json")),
+        )
+
+    @Test
+    fun `LEAN mode should only record unmatched requests`() {
+        val journal = RequestJournal(JournalMode.LEAN)
+
+        journal.recordMatched(request1)
+        journal.recordUnmatched(request2)
+
+        journal.getMatched().shouldBeEmpty()
+        journal.getUnmatched() shouldBe listOf(request2)
+    }
+
+    @Test
+    fun `FULL mode should record both matched and unmatched requests`() {
+        val journal = RequestJournal(JournalMode.FULL)
+
+        journal.recordMatched(request1)
+        journal.recordUnmatched(request2)
+
+        journal.getMatched() shouldBe listOf(request1)
+        journal.getUnmatched() shouldBe listOf(request2)
+    }
+
+    @Test
+    fun `clear should empty both matched and unmatched history`() {
+        val journal = RequestJournal(JournalMode.FULL)
+
+        journal.recordMatched(request1)
+        journal.recordUnmatched(request2)
+
+        journal.getMatched() shouldHaveSize 1
+        journal.getUnmatched() shouldHaveSize 1
+
+        journal.clear()
+
+        journal.getMatched().shouldBeEmpty()
+        journal.getUnmatched().shouldBeEmpty()
+    }
+}

--- a/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/request/RequestJournalStressTest.kt
+++ b/mokksy/src/jvmTest/kotlin/dev/mokksy/mokksy/request/RequestJournalStressTest.kt
@@ -1,0 +1,52 @@
+package dev.mokksy.mokksy.request
+
+import dev.mokksy.mokksy.JournalMode
+import io.ktor.http.HttpMethod
+import org.jetbrains.lincheck.datastructures.ModelCheckingOptions
+import org.jetbrains.lincheck.datastructures.Operation
+import org.jetbrains.lincheck.datastructures.StressOptions
+import kotlin.test.Test
+
+/**
+ * Lincheck stress test for [RequestJournal] to verify thread-safety
+ * and linearizability of concurrent operations.
+ */
+class RequestJournalStressTest {
+    private val journal = RequestJournal(JournalMode.FULL)
+
+    // Pre-create requests to avoid lincheck transforming Ktor classes
+    private val matchedRequest = RecordedRequest(HttpMethod.Get, "/matched", emptyMap())
+    private val unmatchedRequest = RecordedRequest(HttpMethod.Get, "/unmatched", emptyMap())
+
+    @Operation
+    fun recordMatched() {
+        journal.recordMatched(matchedRequest)
+    }
+
+    @Operation
+    fun recordUnmatched() {
+        journal.recordUnmatched(unmatchedRequest)
+    }
+
+    @Operation
+    fun getMatchedCount(): Int = journal.getMatched().size
+
+    @Operation
+    fun getUnmatchedCount(): Int = journal.getUnmatched().size
+
+    @Test
+    fun stressTest() {
+        StressOptions()
+            .invocationsPerIteration(100)
+            .iterations(10)
+            .check(this::class)
+    }
+
+    @Test
+    fun modelCheckingTest() {
+        ModelCheckingOptions()
+            .invocationsPerIteration(100)
+            .iterations(10)
+            .check(this::class)
+    }
+}


### PR DESCRIPTION
Adds a request journaling system (RecordedRequest + RequestJournal), threads it through request handling, exposes APIs to inspect/verify unmatched stubs and requests, adds JournalMode (LEAN/FULL) config, moves CapturedRequest into a request package, and updates docs and test teardown to run both verifications.

- Introduced `RequestJournal` and `JournalMode` enums to record incoming HTTP requests, allowing differentiation between matched and unmatched requests.
- Updated `ServerConfiguration` to include `journalMode` property, defaulting to `LEAN` mode for lower overhead.
- Enhanced request handling by recording requests in `RequestJournal`, and implemented methods to retrieve and clear matched and unmatched requests for post-test verification.
- Updated Mokksy documentation