### PR TITLE
fix: Add missing matchers and fix overlapping stub matchers

### DIFF
--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiNegativeTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiNegativeTest.kt
@@ -64,6 +64,7 @@ internal class ChatCompletionGenaiNegativeTest {
     fun `Should miss response when request does not match`(
         mutator: GenerateContentConfig.Builder.() -> Unit,
     ) {
+        val systemMessage = "You are a helpful pirate."
         mock.generateContent {
             temperature = temperatureValue
             seed = seedValue
@@ -74,7 +75,7 @@ internal class ChatCompletionGenaiNegativeTest {
             location = locationId
             apiVersion = "v1beta1"
             maxOutputTokens(maxCompletionTokensValue)
-            systemMessageContains("You are a helpful pirate.")
+            systemMessageContains(systemMessage)
             userMessageContains("Just say 'Hello!'")
         } responds {
             content = "Ahoy there, matey! Hello!"
@@ -93,7 +94,7 @@ internal class ChatCompletionGenaiNegativeTest {
                     Content
                         .builder()
                         .role("system")
-                        .parts(Part.fromText("You are a helpful pirate."))
+                        .parts(Part.fromText(systemMessage))
                         .build(),
                 )
         mutator(configBuilder)

--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiNegativeTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiNegativeTest.kt
@@ -74,7 +74,7 @@ internal class ChatCompletionGenaiNegativeTest {
             location = locationId
             apiVersion = "v1beta1"
             maxOutputTokens(maxCompletionTokensValue)
-            systemMessageContains("You are a helpful pirate. $seedValue")
+            systemMessageContains("You are a helpful pirate.")
             userMessageContains("Just say 'Hello!'")
         } responds {
             content = "Ahoy there, matey! Hello!"
@@ -93,7 +93,7 @@ internal class ChatCompletionGenaiNegativeTest {
                     Content
                         .builder()
                         .role("system")
-                        .parts(Part.fromText("You are a helpful pirate. $seedValue"))
+                        .parts(Part.fromText("You are a helpful pirate."))
                         .build(),
                 )
         mutator(configBuilder)

--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiTest.kt
@@ -12,6 +12,7 @@ import kotlin.time.Duration.Companion.milliseconds
 internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
     @Test
     fun `Should respond with stream to generateContent`() {
+        val systemMessage = "You are a helpful pirate."
         gemini.generateContent {
             temperature = temperatureValue
             model = modelName
@@ -22,7 +23,7 @@ internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
             topK = topKValue
             topP = topPValue
             maxOutputTokens(maxCompletionTokensValue)
-            systemMessageContains("You are a helpful pirate.")
+            systemMessageContains(systemMessage)
             userMessageContains("Just say 'Hello!'")
         } responds {
             content = "Ahoy there, matey! Hello!"
@@ -32,12 +33,11 @@ internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
         val response =
             client.models.generateContent(
                 modelName,
-                "Just say 'Hello!'",
-                generateContentConfig("You are a helpful pirate.")
+                "Just say 'Hello!' as you do it",
+                generateContentConfig(systemMessage)
                     .build(),
             )
 
         response.text() shouldBe "Ahoy there, matey! Hello!"
     }
-
 }

--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/ChatCompletionGenaiTest.kt
@@ -22,7 +22,7 @@ internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
             topK = topKValue
             topP = topPValue
             maxOutputTokens(maxCompletionTokensValue)
-            systemMessageContains("You are a helpful pirate. $seedValue")
+            systemMessageContains("You are a helpful pirate.")
             userMessageContains("Just say 'Hello!'")
         } responds {
             content = "Ahoy there, matey! Hello!"
@@ -33,7 +33,7 @@ internal class ChatCompletionGenaiTest : AbstractGenaiTest() {
             client.models.generateContent(
                 modelName,
                 "Just say 'Hello!'",
-                generateContentConfig("You are a helpful pirate. $seedValue")
+                generateContentConfig("You are a helpful pirate.")
                     .build(),
             )
 

--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/StreamingChatCompletionGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/StreamingChatCompletionGenaiTest.kt
@@ -14,7 +14,7 @@ import kotlin.time.Duration.Companion.milliseconds
 internal class StreamingChatCompletionGenaiTest : AbstractGenaiTest() {
     @Test
     fun `Should respond with stream to generateContentStream`() {
-        val systemMessage = "You are a helpful pirate. $seedValue"
+        val systemMessage = "You are a helpful pirate."
         gemini.generateContentStream {
             temperature = temperatureValue
             apiVersion = "v1beta1"

--- a/ai-mocks-ollama/api/ai-mocks-ollama.api
+++ b/ai-mocks-ollama/api/ai-mocks-ollama.api
@@ -228,6 +228,7 @@ public final class dev/mokksy/aimocks/ollama/chat/OllamaChatRequestSpecification
 	public final fun getSeed ()Ljava/lang/Integer;
 	public final fun getStream ()Ljava/lang/Boolean;
 	public final fun messages (Ljava/util/List;)Ldev/mokksy/aimocks/ollama/chat/OllamaChatRequestSpecification;
+	public final fun seed (I)Ldev/mokksy/aimocks/ollama/chat/OllamaChatRequestSpecification;
 	public final fun setMessages (Ljava/util/List;)V
 	public final fun setSeed (Ljava/lang/Integer;)V
 	public final fun setStream (Ljava/lang/Boolean;)V
@@ -549,8 +550,11 @@ public final class dev/mokksy/aimocks/ollama/generate/OllamaGenerateBuildingStep
 
 public final class dev/mokksy/aimocks/ollama/generate/OllamaGenerateRequestSpecification : dev/mokksy/aimocks/core/AbstractInferenceRequestSpecification {
 	public fun <init> ()V
+	public final fun getSeed ()Ljava/lang/Integer;
 	public final fun getStream ()Ljava/lang/Boolean;
 	public final fun getTemplate ()Ljava/lang/String;
+	public final fun seed (I)Ldev/mokksy/aimocks/ollama/generate/OllamaGenerateRequestSpecification;
+	public final fun setSeed (Ljava/lang/Integer;)V
 	public final fun setStream (Ljava/lang/Boolean;)V
 	public final fun setTemplate (Ljava/lang/String;)V
 	public final fun stream (Z)Ldev/mokksy/aimocks/ollama/generate/OllamaGenerateRequestSpecification;

--- a/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/MockOllama.kt
+++ b/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/MockOllama.kt
@@ -48,7 +48,6 @@ public open class MockOllama(
                 )
             },
     ) {
-
     /**
      * Sets up a mock handler for the Ollama `/api/generate` completion endpoint.
      *
@@ -80,23 +79,23 @@ public open class MockOllama(
                 }
 
                 generateRequestSpec.seed?.let {
-                    bodyString += containJsonKeyValue("options.seed", it)
+                    bodyString += containJsonKeyValue("$.options.seed", it)
                 }
 
                 generateRequestSpec.temperature?.let {
-                    bodyString += containJsonKeyValue("options.temperature", it)
+                    bodyString += containJsonKeyValue("$.options.temperature", it)
                 }
 
                 generateRequestSpec.topP?.let {
-                    bodyString += containJsonKeyValue("options.top_p", it)
+                    bodyString += containJsonKeyValue("$.options.top_p", it)
                 }
 
                 generateRequestSpec.topK?.let {
-                    bodyString += containJsonKeyValue("options.top_k", it)
+                    bodyString += containJsonKeyValue("$.options.top_k", it)
                 }
 
                 generateRequestSpec.maxTokens?.let {
-                    bodyString += containJsonKeyValue("options.num_predict", it)
+                    bodyString += containJsonKeyValue("$.options.num_predict", it)
                 }
 
                 generateRequestSpec.template?.let {
@@ -149,23 +148,23 @@ public open class MockOllama(
                 }
 
                 chatRequestSpec.seed?.let {
-                    bodyString += containJsonKeyValue("options.seed", it)
+                    bodyString += containJsonKeyValue("$.options.seed", it)
                 }
 
                 chatRequestSpec.temperature?.let {
-                    bodyString += containJsonKeyValue("options.temperature", it)
+                    bodyString += containJsonKeyValue("$.options.temperature", it)
                 }
 
                 chatRequestSpec.topP?.let {
-                    bodyString += containJsonKeyValue("options.top_p", it)
+                    bodyString += containJsonKeyValue("$.options.top_p", it)
                 }
 
                 chatRequestSpec.topK?.let {
-                    bodyString += containJsonKeyValue("options.top_k", it)
+                    bodyString += containJsonKeyValue("$.options.top_k", it)
                 }
 
                 chatRequestSpec.maxTokens?.let {
-                    bodyString += containJsonKeyValue("options.num_predict", it)
+                    bodyString += containJsonKeyValue("$.options.num_predict", it)
                 }
 
                 body += chatRequestSpec.requestBody
@@ -226,7 +225,7 @@ public open class MockOllama(
 
                 embedRequestSpec.options?.let { options ->
                     options.forEach { (key, value) ->
-                        bodyString += containJsonKeyValue("options.$key", value)
+                        bodyString += containJsonKeyValue("$.options.$key", value)
                     }
                 }
 

--- a/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/MockOllama.kt
+++ b/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/MockOllama.kt
@@ -79,6 +79,26 @@ public open class MockOllama(
                     bodyString += containJsonKeyValue("model", it)
                 }
 
+                generateRequestSpec.seed?.let {
+                    bodyString += containJsonKeyValue("options.seed", it)
+                }
+
+                generateRequestSpec.temperature?.let {
+                    bodyString += containJsonKeyValue("options.temperature", it)
+                }
+
+                generateRequestSpec.topP?.let {
+                    bodyString += containJsonKeyValue("options.top_p", it)
+                }
+
+                generateRequestSpec.topK?.let {
+                    bodyString += containJsonKeyValue("options.top_k", it)
+                }
+
+                generateRequestSpec.maxTokens?.let {
+                    bodyString += containJsonKeyValue("options.num_predict", it)
+                }
+
                 generateRequestSpec.template?.let {
                     bodyString += containJsonKeyValue("template", it)
                 }
@@ -142,6 +162,10 @@ public open class MockOllama(
 
                 chatRequestSpec.topK?.let {
                     bodyString += containJsonKeyValue("options.top_k", it)
+                }
+
+                chatRequestSpec.maxTokens?.let {
+                    bodyString += containJsonKeyValue("options.num_predict", it)
                 }
 
                 body += chatRequestSpec.requestBody

--- a/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/chat/OllamaChatRequestSpecification.kt
+++ b/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/chat/OllamaChatRequestSpecification.kt
@@ -47,6 +47,16 @@ public class OllamaChatRequestSpecification : AbstractInferenceRequestSpecificat
     }
 
     /**
+     * Sets the seed value for deterministic behavior in chat completions.
+     *
+     * @param seed The seed value to use for reproducible results.
+     * @return This specification instance for method chaining.
+     * @see <a href="https://docs.ollama.com/api/generate-a-chat-completion#request-reproducible-outputs">Reproducible outputs</a>
+     */
+    public fun seed(seed: Int): OllamaChatRequestSpecification =
+        apply { this.seed = seed }
+
+    /**
      * Sets the list of messages to match in the chat request.
      *
      * @param messages The messages to use as matching criteria.

--- a/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/generate/OllamaGenerateRequestSpecification.kt
+++ b/ai-mocks-ollama/src/commonMain/kotlin/dev/mokksy/aimocks/ollama/generate/OllamaGenerateRequestSpecification.kt
@@ -14,7 +14,9 @@ import dev.mokksy.aimocks.core.AbstractInferenceRequestSpecification
  * @property requestBody The request body to match
  * @property requestBodyString Additional string matchers for the request body
  */
-public class OllamaGenerateRequestSpecification : AbstractInferenceRequestSpecification<GenerateRequest>() {
+public class OllamaGenerateRequestSpecification :
+    AbstractInferenceRequestSpecification<GenerateRequest>() {
+    public var seed: Int? = null
     public var template: String? = null
     public var stream: Boolean? = null
 
@@ -26,6 +28,15 @@ public class OllamaGenerateRequestSpecification : AbstractInferenceRequestSpecif
     override fun systemMessageContains(substring: String) {
         requestMatchesPredicate { it.system?.contains(substring) == true }
     }
+
+    /**
+     * Sets the seed value for deterministic behavior in generate completions.
+     *
+     * @param seed The seed value to use for reproducible results.
+     * @return This specification instance for method chaining.
+     * @see <a href="https://docs.ollama.com/api/generate-a-completion#request-reproducible-outputs">Reproducible outputs</a>
+     */
+    public fun seed(seed: Int): OllamaGenerateRequestSpecification = apply { this.seed = seed }
 
     /**
      * Specifies that the request's prompt must contain the given substring.

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/AbstractMockOllamaTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/AbstractMockOllamaTest.kt
@@ -12,6 +12,7 @@ internal abstract class AbstractMockOllamaTest {
     protected var seedValue: Int = 42
     protected var topPValue: Double = -1.0
     protected var topKValue: Long = -1
+    protected var maxTokensValue: Long = -1
     protected lateinit var modelName: String
     protected lateinit var embeddingModelName: String
     protected val logger = KotlinLogging.logger(name = this::class.simpleName!!)
@@ -24,6 +25,7 @@ internal abstract class AbstractMockOllamaTest {
         topPValue = Random.nextDouble(0.1, 1.0)
         topKValue = Random.nextLong(1, 999)
         temperatureValue = Random.nextDouble(0.0, 1.0)
+        maxTokensValue = Random.nextLong(1, 4096)
         seedValue = Random.nextInt(1, 100500)
         startTimestamp = java.time.Instant.now()
     }

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/AbstractMockOllamaTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/AbstractMockOllamaTest.kt
@@ -25,7 +25,7 @@ internal abstract class AbstractMockOllamaTest {
         topPValue = Random.nextDouble(0.1, 1.0)
         topKValue = Random.nextLong(1, 999)
         temperatureValue = Random.nextDouble(0.0, 1.0)
-        maxTokensValue = Random.nextLong(1, 4096)
+        maxTokensValue = Random.nextLong(512, 8000)
         seedValue = Random.nextInt(1, 100500)
         startTimestamp = java.time.Instant.now()
     }

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaChatCompletionTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaChatCompletionTest.kt
@@ -25,6 +25,7 @@ internal class OllamaChatCompletionTest : AbstractOllamaKtorTest() {
             seed = seedValue
             topP = topPValue
             temperature = temperatureValue
+            maxTokens = maxTokensValue
             requestBodyContains(userMessage)
             stream = false
         } responds {
@@ -49,6 +50,7 @@ internal class OllamaChatCompletionTest : AbstractOllamaKtorTest() {
                         temperature = temperatureValue,
                         topP = topPValue,
                         seed = seedValue,
+                        numPredict = maxTokensValue.toInt(),
                     ),
             )
 

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaChatCompletionTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaChatCompletionTest.kt
@@ -27,7 +27,7 @@ internal class OllamaChatCompletionTest : AbstractOllamaKtorTest() {
             temperature = temperatureValue
             maxTokens = maxTokensValue
             requestBodyContains(userMessage)
-            stream = false
+            stream(false)
         } responds {
             content(assistantMessage)
             delay = 42.milliseconds

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaGenerateCompletionTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaGenerateCompletionTest.kt
@@ -21,7 +21,10 @@ internal class OllamaGenerateCompletionTest : AbstractOllamaKtorTest() {
             model = modelName
             temperature = temperatureValue
             topP = topPValue
+            topK = topKValue
+            seed(seedValue)
             maxTokens = maxTokensValue
+            stream(false)
             userMessageContains("Tell me a joke")
         } responds {
             content("Why did the chicken cross the road? To get to the other side!")
@@ -39,6 +42,8 @@ internal class OllamaGenerateCompletionTest : AbstractOllamaKtorTest() {
                     ModelOptions(
                         temperature = temperatureValue,
                         topP = topPValue,
+                        topK = topKValue.toInt(),
+                        seed = seedValue,
                         numPredict = maxTokensValue.toInt(),
                     ),
             )

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaGenerateCompletionTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaGenerateCompletionTest.kt
@@ -21,6 +21,7 @@ internal class OllamaGenerateCompletionTest : AbstractOllamaKtorTest() {
             model = modelName
             temperature = temperatureValue
             topP = topPValue
+            maxTokens = maxTokensValue
             userMessageContains("Tell me a joke")
         } responds {
             content("Why did the chicken cross the road? To get to the other side!")
@@ -38,6 +39,7 @@ internal class OllamaGenerateCompletionTest : AbstractOllamaKtorTest() {
                     ModelOptions(
                         temperature = temperatureValue,
                         topP = topPValue,
+                        numPredict = maxTokensValue.toInt(),
                     ),
             )
 

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaStreamingGenerateCompletionTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaStreamingGenerateCompletionTest.kt
@@ -3,6 +3,7 @@ package dev.mokksy.aimocks.ollama.ktor
 import dev.mokksy.aimocks.ollama.generate.GenerateRequest
 import dev.mokksy.aimocks.ollama.generate.GenerateResponse
 import dev.mokksy.aimocks.ollama.mockOllama
+import dev.mokksy.aimocks.ollama.model.ModelOptions
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.preparePost
@@ -24,6 +25,8 @@ internal class OllamaStreamingGenerateCompletionTest : AbstractOllamaKtorTest() 
 
         mockOllama.generate {
             model = modelName
+            seed(seedValue)
+            stream(true)
             userMessageContains("Tell me a story")
         } respondsStream {
             responseChunks = chunks
@@ -95,6 +98,7 @@ internal class OllamaStreamingGenerateCompletionTest : AbstractOllamaKtorTest() 
                 model = modelName,
                 prompt = prompt,
                 stream = true,
+                options = ModelOptions(seed = seedValue),
             )
 
         val responses = mutableListOf<GenerateResponse>()

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaStreamingGenerateCompletionTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/ktor/OllamaStreamingGenerateCompletionTest.kt
@@ -51,7 +51,7 @@ internal class OllamaStreamingGenerateCompletionTest : AbstractOllamaKtorTest() 
 
         mockOllama.generate {
             model = modelName
-            userMessageContains("Any prompt")
+            userMessageContains("Flow streaming test")
         } respondsStream {
             responseFlow =
                 flow {
@@ -60,7 +60,7 @@ internal class OllamaStreamingGenerateCompletionTest : AbstractOllamaKtorTest() 
             doneReason("stop")
         }
 
-        val responses = collectStreamingResponses("Any prompt")
+        val responses = collectStreamingResponses("Flow streaming test")
 
         val contentChunks = responses.filter { !it.done }
         val finalChunk = responses.last()
@@ -77,12 +77,12 @@ internal class OllamaStreamingGenerateCompletionTest : AbstractOllamaKtorTest() 
     suspend fun `Should include model name in all chunks`() {
         mockOllama.generate {
             model = modelName
-            userMessageContains("prompt")
+            userMessageContains("model name check")
         } respondsStream {
             responseChunks = listOf("test chunk")
         }
 
-        val responses = collectStreamingResponses("prompt")
+        val responses = collectStreamingResponses("model name check")
 
         responses.forEach { chunk ->
             chunk.model shouldBe modelName

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/lc4j/OllamaChatCompletionLc4jTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/lc4j/OllamaChatCompletionLc4jTest.kt
@@ -26,7 +26,7 @@ internal class OllamaChatCompletionLc4jTest : AbstractMockOllamaTest() {
         // Configure mock response
         mockOllama.chat {
             model = modelName
-            userMessageContains("Hello")
+            userMessageContains("Lc4j chat test")
             temperature = temperatureValue
             topP = topPValue
             requestMatchesPredicate { !it.stream }
@@ -39,7 +39,7 @@ internal class OllamaChatCompletionLc4jTest : AbstractMockOllamaTest() {
         val startTime = TimeSource.Monotonic.markNow()
         val result =
             model.chat {
-                messages += userMessage("Hello")
+                messages += userMessage("Lc4j chat test")
                 parameters {
                     temperature = temperatureValue
                 }

--- a/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/lc4j/OllamaStreamingChatCompletionLc4jTest.kt
+++ b/ai-mocks-ollama/src/jvmTest/kotlin/dev/mokksy/aimocks/ollama/lc4j/OllamaStreamingChatCompletionLc4jTest.kt
@@ -47,7 +47,7 @@ internal class OllamaStreamingChatCompletionLc4jTest : AbstractMockOllamaTest() 
             model = modelName
             seed = seedValue
             temperature = temperatureValue
-            userMessageContains("Hello")
+            userMessageContains("Lc4j streaming test")
             topP = topPValue
             topK = topKValue
             stream = true
@@ -67,7 +67,7 @@ internal class OllamaStreamingChatCompletionLc4jTest : AbstractMockOllamaTest() 
             measureTime {
                 model
                     .chatFlow {
-                        messages += userMessage("Hello")
+                        messages += userMessage("Lc4j streaming test")
                     }.collect { reply ->
                         when (reply) {
                             is StreamingChatModelReply.PartialResponse -> {

--- a/ai-mocks-openai/samples/shadow/pom.xml
+++ b/ai-mocks-openai/samples/shadow/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
-                <version>1.9.25</version>
+                <version>2.1.21</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/ai-mocks-openai/samples/shadow/src/test/java/com/example/OpenAITest.java
+++ b/ai-mocks-openai/samples/shadow/src/test/java/com/example/OpenAITest.java
@@ -3,12 +3,13 @@ package com.example;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.core.JsonValue;
-import com.openai.errors.OpenAIInvalidDataException;
+import com.openai.errors.InternalServerException;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessageParam;
 import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
 import dev.mokksy.aimocks.openai.MockOpenai;
+import dev.mokksy.relocated.io.ktor.http.HttpStatusCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +75,7 @@ class OpenAITest {
             req.maxTokens(maxTokens);
         }).respondsError(response -> {
             response.setBody("Ahh, ohh!");
-            response.setHttpStatusCode(500);
+            response.setHttpStatus(HttpStatusCode.Companion.getInternalServerError());
         });
 
         final ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
@@ -88,7 +89,7 @@ class OpenAITest {
             .model(ChatModel.GPT_4O_MINI)
             .build();
 
-        assertThatExceptionOfType(OpenAIInvalidDataException.class)
+        assertThatExceptionOfType(InternalServerException.class)
             .isThrownBy(() -> CLIENT.chat().completions().create(params));
     }
 }

--- a/ai-mocks-openai/src/commonMain/kotlin/dev/mokksy/aimocks/openai/MockOpenai.kt
+++ b/ai-mocks-openai/src/commonMain/kotlin/dev/mokksy/aimocks/openai/MockOpenai.kt
@@ -107,6 +107,10 @@ public open class MockOpenai(
                 requestSpec.model?.let {
                     bodyString += containJsonKeyValue("model", it)
                 }
+
+                requestSpec.topP?.let {
+                    bodyString += containJsonKeyValue("top_p", it)
+                }
             }
 
         return OpenaiChatCompletionsBuildingStep(
@@ -152,6 +156,10 @@ public open class MockOpenai(
 
                 chatRequestSpec.model?.let {
                     bodyString += containJsonKeyValue("model", it)
+                }
+
+                chatRequestSpec.topP?.let {
+                    bodyString += containJsonKeyValue("top_p", it)
                 }
 
                 chatRequestSpec.requestBodyString.forEach {

--- a/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/lc4j/OpenaiChatCompletionLc4jTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/lc4j/OpenaiChatCompletionLc4jTest.kt
@@ -9,8 +9,7 @@ import dev.mokksy.aimocks.openai.AbstractMockOpenaiTest
 import dev.mokksy.aimocks.openai.openai
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.coroutines.runBlocking
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 internal class OpenaiChatCompletionLc4jTest : AbstractMockOpenaiTest() {
@@ -22,36 +21,36 @@ internal class OpenaiChatCompletionLc4jTest : AbstractMockOpenaiTest() {
             .build()
 
     @Test
-    fun `Should respond to Chat Completion`(): Unit =
-        runBlocking {
-            openai.completion {
-                temperature = temperatureValue
-                seed = seedValue
-                model = modelName
-                maxTokens = maxCompletionTokensValue
-            } responds {
-                assistantContent = "Hello"
-                finishReason = "stop"
-                delay = 42.milliseconds
-            }
-
-            val result =
-                model.chat {
-                    parameters =
-                        OpenAiChatRequestParameters
-                            .builder()
-                            .maxCompletionTokens(maxCompletionTokensValue.toInt())
-                            .temperature(temperatureValue)
-                            .modelName(modelName)
-                            .seed(seedValue)
-                            .build()
-                    messages += userMessage("Say Hello")
-                }
-
-            result.apply {
-                finishReason() shouldBe FinishReason.STOP
-                tokenUsage() shouldNotBe null
-                aiMessage().text() shouldBe "Hello"
-            }
+    suspend fun `Should respond to Chat Completion`() {
+        openai.completion {
+            temperature = temperatureValue
+            seed = seedValue
+            model = modelName
+            maxTokens = maxCompletionTokensValue
+            userMessageContains("Lc4j chat test")
+        } responds {
+            assistantContent = "Hello"
+            finishReason = "stop"
+            delay = 42.milliseconds
         }
+
+        val result =
+            model.chat {
+                parameters =
+                    OpenAiChatRequestParameters
+                        .builder()
+                        .maxCompletionTokens(maxCompletionTokensValue.toInt())
+                        .temperature(temperatureValue)
+                        .modelName(modelName)
+                        .seed(seedValue)
+                        .build()
+                messages += userMessage("Lc4j chat test")
+            }
+
+        result.apply {
+            finishReason() shouldBe FinishReason.STOP
+            tokenUsage() shouldNotBe null
+            aiMessage().text() shouldBe "Hello"
+        }
+    }
 }

--- a/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/lc4j/OpenaiStreamingChatCompletionLc4jTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/lc4j/OpenaiStreamingChatCompletionLc4jTest.kt
@@ -44,14 +44,14 @@ internal class StreamingChatCompletionLc4jTest : AbstractMockOpenaiTest() {
                 seed = seedValue
                 userMessageContains("What do we need?")
             } respondsStream {
-                responseChunks = listOf("All", " we", " need", " is", " Love")
+                responseChunks = listOf("Lc4j", " All", " we", " need", " is", " Love")
                 finishReason = "stop"
 
                 // send "[DONE]" as last message to finish the stream in openai4j
                 sendDone = true
             }
 
-            verifyStreamingKotlinFlow("What do we need?", "All we need is Love")
+            verifyStreamingKotlinFlow("What do we need?", "Lc4j All we need is Love")
         }
 
     @Test

--- a/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/official/completions/ChatCompletionOpenaiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/official/completions/ChatCompletionOpenaiTest.kt
@@ -17,21 +17,22 @@ import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTimedValue
 
 internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
     @Test
     fun `Should respond to Chat Completion`() {
+        val testSeed = seedValue
         openai.completion {
             temperature = temperatureValue
-            seed = seedValue
+            seed = testSeed
             model = modelName
             topP = topPValue
             maxTokens = maxCompletionTokensValue
-            systemMessageContains("helpful assistant")
-            userMessageContains("say 'Hello!'")
+            systemMessageContains("OpenAI official")
+            userMessageContains("Just say 'Hello!' and nothing else")
         } responds {
             assistantContent = "Hello"
             finishReason = "stop"
@@ -39,7 +40,7 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
         }
 
         val params =
-            createChatCompletionRequestParams()
+            createChatCompletionRequestParams(testSeed)
 
         val timedValue =
             measureTimedValue {
@@ -65,6 +66,7 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
 
     @Test
     fun `Should respond with unexpected error`() {
+        val testSeed = seedValue
         val carambaResponse =
             // language=json
             """
@@ -78,11 +80,11 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
         openai
             .completion {
                 temperature = temperatureValue
-                seed = seedValue
+                seed = testSeed
                 model = modelName
                 maxTokens = maxCompletionTokensValue
-                systemMessageContains("helpful assistant")
-                userMessageContains("say 'Hello!'")
+                systemMessageContains("OpenAI official")
+                userMessageContains("Just say 'Hello!' and nothing else")
             }.respondsError(String::class) {
                 body = carambaResponse
                 contentType = ContentType.Text.Plain
@@ -91,7 +93,7 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
             }
 
         val params =
-            createChatCompletionRequestParams()
+            createChatCompletionRequestParams(testSeed)
 
         val timedValue =
             measureTimedValue {
@@ -110,6 +112,7 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
 
     @Test
     fun `Should respond with error 500`() {
+        val testSeed = seedValue
         val errorResponse =
             // language=json
             """
@@ -125,11 +128,11 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
         openai
             .completion {
                 temperature = temperatureValue
-                seed = seedValue
+                seed = testSeed
                 model = modelName
                 maxTokens = maxCompletionTokensValue
-                systemMessageContains("helpful assistant")
-                userMessageContains("say 'Hello!'")
+                systemMessageContains("OpenAI official")
+                userMessageContains("Just say 'Hello!' and nothing else")
             }.respondsError(String::class) {
                 body = errorResponse
                 delay = 150.milliseconds
@@ -138,7 +141,7 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
             }
 
         val params =
-            createChatCompletionRequestParams()
+            createChatCompletionRequestParams(testSeed)
 
         val timedValue =
             measureTimedValue {
@@ -169,15 +172,15 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
         }
     }
 
-    private fun createChatCompletionRequestParams(): ChatCompletionCreateParams {
+    private fun createChatCompletionRequestParams(testSeed: Int): ChatCompletionCreateParams {
         val params =
-            @Suppress("deprecation")
+            @Suppress("DEPRECATION")
             ChatCompletionCreateParams
                 .builder()
                 .temperature(temperatureValue)
                 .topP(topPValue)
                 .maxCompletionTokens(maxCompletionTokensValue)
-                .seed(seedValue.toLong())
+                .seed(testSeed.toLong())
                 .responseFormat(
                     ResponseFormatJsonSchema
                         .builder()
@@ -199,7 +202,7 @@ internal class ChatCompletionOpenaiTest : AbstractOpenaiTest() {
                             ChatCompletionSystemMessageParam
                                 .builder()
                                 .content(
-                                    "You are a helpful assistant.",
+                                    "You are a helpful assistant. OpenAI official",
                                 ).build(),
                         ),
                         ChatCompletionMessageParam.ofUser(

--- a/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/official/completions/StreamingChatCompletionOpenaiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/official/completions/StreamingChatCompletionOpenaiTest.kt
@@ -22,6 +22,7 @@ internal class StreamingChatCompletionOpenaiTest : AbstractOpenaiTest() {
             temperature = temperatureValue
             model = modelName
             topP = topPValue
+            userMessageContains("OpenAI streaming list test")
         } respondsStream {
             responseChunks = listOf("All", " we", " need", " is", " Love")
             delay = 50.milliseconds
@@ -29,7 +30,7 @@ internal class StreamingChatCompletionOpenaiTest : AbstractOpenaiTest() {
             finishReason = "stop"
         }
 
-        verifyStreamingCall()
+        verifyStreamingCall("OpenAI streaming list test")
     }
 
     @Test
@@ -37,6 +38,7 @@ internal class StreamingChatCompletionOpenaiTest : AbstractOpenaiTest() {
         openai.completion("openai-completions-flow") {
             temperature = temperatureValue
             model = modelName
+            userMessageContains("OpenAI streaming flow test")
         } respondsStream {
             responseFlow =
                 flow {
@@ -51,10 +53,10 @@ internal class StreamingChatCompletionOpenaiTest : AbstractOpenaiTest() {
             finishReason = "stop"
         }
 
-        verifyStreamingCall()
+        verifyStreamingCall("OpenAI streaming flow test")
     }
 
-    private fun verifyStreamingCall() {
+    private fun verifyStreamingCall(userMessage: String) {
         val params =
             @Suppress("deprecation")
             ChatCompletionCreateParams
@@ -72,7 +74,7 @@ internal class StreamingChatCompletionOpenaiTest : AbstractOpenaiTest() {
                                 .role(JsonValue.from("user"))
                                 .content(
                                     ChatCompletionUserMessageParam.Content.ofText(
-                                        "What do we need?",
+                                        userMessage,
                                     ),
                                 ).build(),
                         ),

--- a/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/springai/OpenaiChatCompletionSpringAiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/springai/OpenaiChatCompletionSpringAiTest.kt
@@ -22,7 +22,7 @@ internal class OpenaiChatCompletionSpringAiTest : AbstractSpringAiTest() {
             seed = seedValue
             model = modelName
             maxTokens = maxCompletionTokensValue
-            systemMessageContains("helpful merchant")
+            systemMessageContains("SpringAI chat merchant")
             userMessageContains("say 'Hello!'")
             requestMatchesPredicate {
                 !it.stream
@@ -33,7 +33,7 @@ internal class OpenaiChatCompletionSpringAiTest : AbstractSpringAiTest() {
         }
 
         val response =
-            prepareClientRequest("You are a helpful merchant")
+            prepareClientRequest("You are a SpringAI chat merchant")
                 .call()
                 .chatResponse()
 
@@ -50,7 +50,7 @@ internal class OpenaiChatCompletionSpringAiTest : AbstractSpringAiTest() {
             seed = seedValue
             model = modelName
             maxTokens = maxCompletionTokensValue
-            systemMessageContains("helpful pirate")
+            systemMessageContains("SpringAI streaming pirate")
             userMessageContains("say 'Hello!'")
             requestMatches(beOfType(ChatCompletionRequest::class))
             requestSatisfies("Should be streamed") {
@@ -71,7 +71,7 @@ internal class OpenaiChatCompletionSpringAiTest : AbstractSpringAiTest() {
         }
 
         val chunks =
-            prepareClientRequest("You are a helpful pirate")
+            prepareClientRequest("You are a SpringAI streaming pirate")
                 .stream()
                 .chatResponse()
                 .collectList()

--- a/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/springai/OpenaiStreamingChatCompletionSpringAiTest.kt
+++ b/ai-mocks-openai/src/jvmTest/kotlin/dev/mokksy/aimocks/openai/springai/OpenaiStreamingChatCompletionSpringAiTest.kt
@@ -17,7 +17,7 @@ internal class OpenaiStreamingChatCompletionSpringAiTest : AbstractSpringAiTest(
             seed = seedValue
             model = modelName
             maxTokens = maxCompletionTokensValue
-            systemMessageContains("helpful pirate")
+            systemMessageContains("SpringAI streaming standalone")
             userMessageContains("say 'Hello!'")
         } respondsStream {
             responseFlow =
@@ -34,7 +34,7 @@ internal class OpenaiStreamingChatCompletionSpringAiTest : AbstractSpringAiTest(
         }
 
         val chunks =
-            prepareClientRequest("You are a helpful pirate")
+            prepareClientRequest("You are a SpringAI streaming standalone")
                 .stream()
                 .chatResponse()
                 .collectList()


### PR DESCRIPTION
## Summary
- **Fix overlapping stub matchers** across Ollama, OpenAI, and Gemini tests that caused 404s when using a shared mock server instance
- **Add `maxTokens` matcher** to `MockOllama` generate and chat endpoints (maps to `options.num_predict` per Ollama API)
- **Add `seed` property and fluent method** to `OllamaGenerateRequestSpecification` and `OllamaChatRequestSpecification`
- **Add `top_p` matching** to `MockOpenai`
- **Remove redundant `$seedValue`** from Gemini test string payloads (seed is already matched as a separate JSON field)
- Fixed sample test (reflect breaking change)

## Root Cause
Shared mock server instances require unique, non-overlapping stub matchers per test. Tests were using identical string matchers (e.g., `"OpenAI error 500"`) without unique differentiators like `seed` or `top_p`, causing stub collisions and 404 responses.
## Changes by Module
### ai-mocks-ollama
- `MockOllama.kt` — Added `maxTokens` matcher for both generate and chat endpoints
- `OllamaGenerateRequestSpecification.kt` — Added `seed` property and `seed(seed: Int)` fluent method
- `OllamaChatRequestSpecification.kt` — Added `seed` property and `seed(seed: Int)` fluent method
- `AbstractMockOllamaTest.kt` — Added `maxTokensValue` with random generation
- Ktor/Lc4j tests — Fixed overlapping matchers, added `maxTokens` verification
### ai-mocks-openai
- `MockOpenai.kt` — Added `top_p` matcher
- Ktor/SpringAI/Lc4j tests — Fixed overlapping matchers, aligned string matchers with actual request content
### ai-mocks-gemini
- GenAI tests — Removed redundant `$seedValue` from string payloads