### PR TITLE
fix(gemini): support delays in gemini streaming

### DIFF
--- a/ai-mocks-gemini/src/commonMain/kotlin/dev/mokksy/aimocks/gemini/content/GeminiStreamingContentBuildingStep.kt
+++ b/ai-mocks-gemini/src/commonMain/kotlin/dev/mokksy/aimocks/gemini/content/GeminiStreamingContentBuildingStep.kt
@@ -63,6 +63,8 @@ public class GeminiStreamingContentBuildingStep(
             }
             val request = this.request.body()
             val responseId = Uuid.random().toHexString()
+            delayBetweenChunks = responseSpec.delayBetweenChunks
+            delay = responseSpec.delay
             flow =
                 prepareFlow(
                     responseId = responseId,

--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/StreamingChatCompletionGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/StreamingChatCompletionGenaiTest.kt
@@ -1,11 +1,14 @@
 package dev.mokksy.aimocks.gemini.genai
 
 import dev.mokksy.aimocks.gemini.gemini
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTimedValue
 
 /**
  * Some examples:
@@ -15,6 +18,10 @@ internal class StreamingChatCompletionGenaiTest : AbstractGenaiTest() {
     @Test
     fun `Should respond with stream to generateContentStream`() {
         val systemMessage = "You are a helpful pirate."
+        val initialDelay = 60.milliseconds
+        val flowDelay = 100.milliseconds
+        val delayBetweenChunks = 15.milliseconds
+        val tokens = listOf("Ahoy", " there,", " matey!", " Hello!")
         gemini.generateContentStream {
             temperature = temperatureValue
             apiVersion = "v1beta1"
@@ -30,27 +37,36 @@ internal class StreamingChatCompletionGenaiTest : AbstractGenaiTest() {
         } respondsStream {
             responseFlow =
                 flow {
-                    emit("Ahoy")
-                    emit(" there,")
-                    delay(100.milliseconds)
-                    emit(" matey!")
-                    emit(" Hello!")
+                    tokens.forEachIndexed { index, token ->
+                        if (index > 0 && index == 2) {
+                            delay(flowDelay)
+                        }
+                        emit(token)
+                    }
                 }
-            delay = 60.milliseconds
-            delayBetweenChunks = 15.milliseconds
+            delay = initialDelay
+            this.delayBetweenChunks = delayBetweenChunks
         }
 
-        val response =
-            client.models.generateContentStream(
-                modelName,
-                "Just say 'Hello!'",
-                generateContentConfig(systemMessage)
-                    .build(),
-            )
+        val timedValue =
+            measureTimedValue {
+                client.models
+                    .generateContentStream(
+                        modelName,
+                        "Just say 'Hello!'",
+                        generateContentConfig(systemMessage)
+                            .build(),
+                    ).joinToString(separator = "") {
+                        it.text().orEmpty()
+                    }
+            }
 
-        response.joinToString(separator = "") {
-            it.text().orEmpty()
-        } shouldBe "Ahoy there, matey! Hello!"
+        timedValue.value shouldBe "Ahoy there, matey! Hello!"
+
+        val expectedMinDuration = initialDelay + flowDelay + delayBetweenChunks * (tokens.size - 1)
+        assertSoftly(timedValue) {
+            value shouldBe "Ahoy there, matey! Hello!"
+            duration shouldBeGreaterThanOrEqualTo expectedMinDuration
+        }
     }
-
 }


### PR DESCRIPTION
## Summary
Fixes two issues in the ai-mocks test suite:

**Gemini streaming delays ignored** — `delay` and `delayBetweenChunks` from response spec were never propagated to the mock server, causing timing assertions to fail

## Changes

**`ai-mocks-gemini/src/commonMain/kotlin/.../GeminiStreamingContentBuildingStep.kt`**
- Added propagation of `delayBetweenChunks` and `delay` from `responseSpec` to the `StreamingResponseDefinitionBuilder`
- Matches the pattern used in `OllamaChatBuildingStep.kt:109-110`
**`ai-mocks-gemini/src/jvmTest/kotlin/.../StreamingChatCompletionGenaiTest.kt`**
- Rewrote test to use `measureTimedValue` for timing verification
- Asserts total duration ≥ `initialDelay + flowDelay + delayBetweenChunks × (tokens - 1)` to confirm delays are properly applied
- Extracted token list to a variable for cleaner test structure