### PR TITLE
fix(gemini): add @serializable to BlockReason and add gemini and a2a tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ development purposes.
 ## Development Guidelines
 
 - Use `git mv` command when renaming files to preserve git history, if possible
-- Never commit or push changes to git automatically. It should be done manually.
+- Never commit or push changes to git automatically. Always confirm.
 - Ensure new code follows existing code style and design patterns.
 - Use MCP servers, if available, to edit code and run tests. Run terminal commands directly.
 
@@ -72,6 +72,7 @@ development purposes.
 ### Testing
 
 - Write comprehensive tests for new features
+- Prioritize test readability
 - Use function `Names with backticks` for test methods in Kotlin, e.g. "fun `should return 200 OK`()"
 - Avoid writing KDocs for tests, keep code self-documenting
 - Write Kotlin tests with [kotlin-test](https://github.com/JetBrains/kotlin/tree/master/libraries/kotlin.test),
@@ -83,10 +84,9 @@ development purposes.
   `params shouldNotBeNull { params.id shouldBe 1 }`
 - For testing json serialization use [Kotest-assertions-json](https://kotest.io/docs/assertions/json/json-overview.html)
   assertions, e.g. `shouldEqualJson` and never compare substrings.
-- Use `assertSoftly(subject) { ... }` to perform multiple assertions. Never use `assertSoftly { }` to verify properties
-  of different subjects, or when there is only one assertion per subject. Avoid using `assertSoftly(this) { ... }`
-  - Prioritize test readability
-  - When asked to write tests in Java: use JUnit5, Mockito, AssertJ core
+- Prefer `assertSoftly(subject) { }` over `assertSoftly { }`. Use the no-subject form only when asserting 
+  the same invariant across multiple related objects, or when the assertions are tightly coupled.
+- When asked to write tests in Java: use JUnit6, Mockito, AssertJ core
 
 #### Parallel Test Execution and Shared Mock Servers
 

--- a/ai-mocks-a2a-models/src/commonTest/kotlin/dev/mokksy/aimocks/a2a/model/SecuritySchemeBuilderTest.kt
+++ b/ai-mocks-a2a-models/src/commonTest/kotlin/dev/mokksy/aimocks/a2a/model/SecuritySchemeBuilderTest.kt
@@ -1,0 +1,553 @@
+package dev.mokksy.aimocks.a2a.model
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.test.Test
+
+internal class SecuritySchemeBuilderTest {
+    @Test
+    fun `should create API key security scheme with header location`() {
+        // when
+        val scheme =
+            SecuritySchemeBuilder.apiKey(
+                name = "X-API-Key",
+                location = ApiKeyLocation.HEADER,
+            )
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<ApiKeySecurityScheme>()
+            type shouldBe "apiKey"
+            name shouldBe "X-API-Key"
+            location shouldBe ApiKeyLocation.HEADER
+        }
+    }
+
+    @Test
+    fun `should create API key security scheme with query location`() {
+        // when
+        val scheme =
+            SecuritySchemeBuilder.apiKey(
+                name = "api_key",
+                location = ApiKeyLocation.QUERY,
+            )
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<ApiKeySecurityScheme>()
+            type shouldBe "apiKey"
+            name shouldBe "api_key"
+            location shouldBe ApiKeyLocation.QUERY
+        }
+    }
+
+    @Test
+    fun `should create API key security scheme with cookie location`() {
+        // when
+        val scheme =
+            SecuritySchemeBuilder.apiKey(
+                name = "session",
+                location = ApiKeyLocation.COOKIE,
+            )
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<ApiKeySecurityScheme>()
+            type shouldBe "apiKey"
+            name shouldBe "session"
+            location shouldBe ApiKeyLocation.COOKIE
+        }
+    }
+
+    @Test
+    fun `should create HTTP security scheme with basic auth`() {
+        // when
+        val scheme = SecuritySchemeBuilder.http(scheme = "basic")
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<HttpSecurityScheme>()
+            type shouldBe "http"
+            this.scheme shouldBe "basic"
+            bearerFormat shouldBe null
+        }
+    }
+
+    @Test
+    fun `should create HTTP security scheme with bearer auth and format`() {
+        // when
+        val scheme =
+            SecuritySchemeBuilder.http(
+                scheme = "bearer",
+                bearerFormat = "JWT",
+            )
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<HttpSecurityScheme>()
+            type shouldBe "http"
+            this.scheme shouldBe "bearer"
+            bearerFormat shouldBe "JWT"
+        }
+    }
+
+    @Test
+    fun `should create HTTP security scheme with bearer auth without format`() {
+        // when
+        val scheme = SecuritySchemeBuilder.http(scheme = "bearer")
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<HttpSecurityScheme>()
+            type shouldBe "http"
+            this.scheme shouldBe "bearer"
+            bearerFormat shouldBe null
+        }
+    }
+
+    @Test
+    fun `should create Mutual TLS security scheme without description`() {
+        // when
+        val scheme = SecuritySchemeBuilder.mutualTLS()
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<MutualTLSSecurityScheme>()
+            type shouldBe "mutualTLS"
+            description shouldBe null
+        }
+    }
+
+    @Test
+    fun `should create Mutual TLS security scheme with description`() {
+        // given
+        val desc = "Client certificate authentication"
+
+        // when
+        val scheme = SecuritySchemeBuilder.mutualTLS(description = desc)
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<MutualTLSSecurityScheme>()
+            type shouldBe "mutualTLS"
+            description shouldBe desc
+        }
+    }
+
+    @Test
+    fun `should create OpenID Connect security scheme`() {
+        // given
+        val url = "https://auth.example.com/.well-known/openid-configuration"
+
+        // when
+        val scheme = SecuritySchemeBuilder.openIdConnect(openIdConnectUrl = url)
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<OpenIdConnectSecurityScheme>()
+            type shouldBe "openIdConnect"
+            openIdConnectUrl shouldBe url
+        }
+    }
+
+    @Test
+    fun `should create OAuth2 scheme without metadata URL`() {
+        // given
+        val flows =
+            OAuth2Flows(
+                implicit =
+                    OAuth2Flow(
+                        authorizationUrl = "https://auth.example.com/authorize",
+                        scopes = mapOf("read" to "Read access"),
+                    ),
+            )
+
+        // when
+        val scheme = SecuritySchemeBuilder.oauth2(flows = flows)
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<OAuth2SecurityScheme>()
+            type shouldBe "oauth2"
+            metadataUrl shouldBe null
+            this.flows shouldBe flows
+        }
+    }
+
+    @Test
+    fun `should create OAuth2 scheme with metadata URL`() {
+        // given
+        val metadataUrl = "https://auth.example.com/.well-known/oauth2"
+        val flows =
+            OAuth2Flows(
+                authorizationCode =
+                    OAuth2Flow(
+                        authorizationUrl = "https://auth.example.com/oauth2/authorize",
+                        tokenUrl = "https://auth.example.com/oauth2/token",
+                        scopes =
+                            mapOf(
+                                "read" to "Read access",
+                                "write" to "Write access",
+                            ),
+                    ),
+            )
+
+        // when
+        val scheme = SecuritySchemeBuilder.oauth2(metadataUrl = metadataUrl, flows = flows)
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<OAuth2SecurityScheme>()
+            type shouldBe "oauth2"
+            this.metadataUrl shouldBe metadataUrl
+            this.flows shouldBe flows
+        }
+    }
+
+    @Test
+    fun `should build implicit OAuth2 flow with DSL`() {
+        // when
+        val builder = OAuth2FlowsBuilder()
+        builder.implicit {
+            authorizationUrl = "https://auth.example.com/authorize"
+            scopes = mapOf("read" to "Read access", "write" to "Write access")
+        }
+        val flows = builder.build()
+
+        // then
+        assertSoftly(flows) {
+            implicit shouldBe
+                OAuth2Flow(
+                    authorizationUrl = "https://auth.example.com/authorize",
+                    scopes = mapOf("read" to "Read access", "write" to "Write access"),
+                )
+            password shouldBe null
+            clientCredentials shouldBe null
+            authorizationCode shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build password OAuth2 flow with DSL`() {
+        // when
+        val builder = OAuth2FlowsBuilder()
+        builder.password {
+            tokenUrl = "https://auth.example.com/token"
+            scopes = mapOf("admin" to "Admin access")
+        }
+        val flows = builder.build()
+
+        // then
+        assertSoftly(flows) {
+            implicit shouldBe null
+            password shouldBe
+                OAuth2Flow(
+                    tokenUrl = "https://auth.example.com/token",
+                    scopes = mapOf("admin" to "Admin access"),
+                )
+            clientCredentials shouldBe null
+            authorizationCode shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build client credentials OAuth2 flow with DSL`() {
+        // when
+        val builder = OAuth2FlowsBuilder()
+        builder.clientCredentials {
+            tokenUrl = "https://auth.example.com/token"
+            scopes = mapOf("api" to "API access")
+        }
+        val flows = builder.build()
+
+        // then
+        assertSoftly(flows) {
+            implicit shouldBe null
+            password shouldBe null
+            clientCredentials shouldBe
+                OAuth2Flow(
+                    tokenUrl = "https://auth.example.com/token",
+                    scopes = mapOf("api" to "API access"),
+                )
+            authorizationCode shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build authorization code OAuth2 flow with DSL`() {
+        // when
+        val builder = OAuth2FlowsBuilder()
+        builder.authorizationCode {
+            authorizationUrl = "https://auth.example.com/authorize"
+            tokenUrl = "https://auth.example.com/token"
+            refreshUrl = "https://auth.example.com/refresh"
+            scopes = mapOf("read" to "Read access", "write" to "Write access")
+        }
+        val flows = builder.build()
+
+        // then
+        assertSoftly(flows) {
+            implicit shouldBe null
+            password shouldBe null
+            clientCredentials shouldBe null
+            authorizationCode shouldBe
+                OAuth2Flow(
+                    authorizationUrl = "https://auth.example.com/authorize",
+                    tokenUrl = "https://auth.example.com/token",
+                    refreshUrl = "https://auth.example.com/refresh",
+                    scopes = mapOf("read" to "Read access", "write" to "Write access"),
+                )
+        }
+    }
+
+    @Test
+    fun `should build multiple OAuth2 flows with DSL`() {
+        // when
+        val builder = OAuth2FlowsBuilder()
+        builder.implicit {
+            authorizationUrl = "https://auth.example.com/authorize"
+            scopes = mapOf("read" to "Read access")
+        }
+        builder.authorizationCode {
+            authorizationUrl = "https://auth.example.com/authorize"
+            tokenUrl = "https://auth.example.com/token"
+            scopes = mapOf("read" to "Read access", "write" to "Write access")
+        }
+        val flows = builder.build()
+
+        // then
+        assertSoftly(flows) {
+            implicit shouldBe
+                OAuth2Flow(
+                    authorizationUrl = "https://auth.example.com/authorize",
+                    scopes = mapOf("read" to "Read access"),
+                )
+            password shouldBe null
+            clientCredentials shouldBe null
+            authorizationCode shouldBe
+                OAuth2Flow(
+                    authorizationUrl = "https://auth.example.com/authorize",
+                    tokenUrl = "https://auth.example.com/token",
+                    scopes = mapOf("read" to "Read access", "write" to "Write access"),
+                )
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with fluent API using authorizationUrl method`() {
+        // when
+        val flow =
+            OAuth2FlowBuilder().authorizationUrl("https://auth.example.com/authorize").build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe "https://auth.example.com/authorize"
+            tokenUrl shouldBe null
+            refreshUrl shouldBe null
+            scopes shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with fluent API using tokenUrl method`() {
+        // when
+        val flow = OAuth2FlowBuilder().tokenUrl("https://auth.example.com/token").build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe null
+            tokenUrl shouldBe "https://auth.example.com/token"
+            refreshUrl shouldBe null
+            scopes shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with fluent API using refreshUrl method`() {
+        // when
+        val flow = OAuth2FlowBuilder().refreshUrl("https://auth.example.com/refresh").build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe null
+            tokenUrl shouldBe null
+            refreshUrl shouldBe "https://auth.example.com/refresh"
+            scopes shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with fluent API using scopes method`() {
+        // given
+        val scopesMap = mapOf("read" to "Read access", "write" to "Write access")
+
+        // when
+        val flow = OAuth2FlowBuilder().scopes(scopesMap).build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe null
+            tokenUrl shouldBe null
+            refreshUrl shouldBe null
+            scopes shouldBe scopesMap
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with fluent API using addScope method`() {
+        // when
+        val flow = OAuth2FlowBuilder().addScope("read", "Read access").build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe null
+            tokenUrl shouldBe null
+            refreshUrl shouldBe null
+            scopes shouldBe mapOf("read" to "Read access")
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with fluent API using multiple addScope calls`() {
+        // when
+        val flow =
+            OAuth2FlowBuilder()
+                .addScope("read", "Read access")
+                .addScope("write", "Write access")
+                .addScope("admin", "Admin access")
+                .build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe null
+            tokenUrl shouldBe null
+            refreshUrl shouldBe null
+            scopes shouldBe
+                mapOf(
+                    "read" to "Read access",
+                    "write" to "Write access",
+                    "admin" to "Admin access",
+                )
+        }
+    }
+
+    @Test
+    fun `should build complete OAuth2 flow with all fluent API methods chained`() {
+        // when
+        val flow =
+            OAuth2FlowBuilder()
+                .authorizationUrl("https://auth.example.com/authorize")
+                .tokenUrl("https://auth.example.com/token")
+                .refreshUrl("https://auth.example.com/refresh")
+                .addScope("read", "Read access")
+                .addScope("write", "Write access")
+                .build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe "https://auth.example.com/authorize"
+            tokenUrl shouldBe "https://auth.example.com/token"
+            refreshUrl shouldBe "https://auth.example.com/refresh"
+            scopes shouldBe mapOf("read" to "Read access", "write" to "Write access")
+        }
+    }
+
+    @Test
+    fun `should create OAuth2 scheme using oauth2SecurityScheme DSL function`() {
+        // when
+        val scheme =
+            oauth2SecurityScheme(metadataUrl = "https://auth.example.com/.well-known/oauth2") {
+                authorizationCode {
+                    authorizationUrl = "https://auth.example.com/oauth2/authorize"
+                    tokenUrl = "https://auth.example.com/oauth2/token"
+                    scopes = mapOf("read" to "Read access", "write" to "Write access")
+                }
+            }
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<OAuth2SecurityScheme>()
+            type shouldBe "oauth2"
+            metadataUrl shouldBe "https://auth.example.com/.well-known/oauth2"
+            flows.authorizationCode shouldBe
+                OAuth2Flow(
+                    authorizationUrl = "https://auth.example.com/oauth2/authorize",
+                    tokenUrl = "https://auth.example.com/oauth2/token",
+                    scopes = mapOf("read" to "Read access", "write" to "Write access"),
+                )
+        }
+    }
+
+    @Test
+    fun `should create OAuth2 scheme using oauth2SecurityScheme DSL without metadata URL`() {
+        // when
+        val scheme =
+            oauth2SecurityScheme {
+                implicit {
+                    authorizationUrl = "https://auth.example.com/authorize"
+                    scopes = mapOf("read" to "Read access")
+                }
+            }
+
+        // then
+        assertSoftly(scheme) {
+            shouldBeInstanceOf<OAuth2SecurityScheme>()
+            type shouldBe "oauth2"
+            metadataUrl shouldBe null
+            flows.implicit shouldBe
+                OAuth2Flow(
+                    authorizationUrl = "https://auth.example.com/authorize",
+                    scopes = mapOf("read" to "Read access"),
+                )
+        }
+    }
+
+    @Test
+    fun `should merge scopes when using both scopes and addScope methods`() {
+        // when
+        val flow =
+            OAuth2FlowBuilder()
+                .scopes(mapOf("read" to "Read access"))
+                .addScope("write", "Write access")
+                .build()
+
+        // then
+        assertSoftly(flow) {
+            scopes shouldBe mapOf("read" to "Read access", "write" to "Write access")
+        }
+    }
+
+    @Test
+    fun `should build empty OAuth2Flows when no flows are configured`() {
+        // when
+        val flows = OAuth2FlowsBuilder().build()
+
+        // then
+        assertSoftly(flows) {
+            implicit shouldBe null
+            password shouldBe null
+            clientCredentials shouldBe null
+            authorizationCode shouldBe null
+        }
+    }
+
+    @Test
+    fun `should build OAuth2 flow with direct property assignment`() {
+        // when
+        val builder = OAuth2FlowBuilder()
+        builder.authorizationUrl = "https://auth.example.com/authorize"
+        builder.tokenUrl = "https://auth.example.com/token"
+        builder.refreshUrl = "https://auth.example.com/refresh"
+        builder.scopes = mapOf("read" to "Read access")
+        val flow = builder.build()
+
+        // then
+        assertSoftly(flow) {
+            authorizationUrl shouldBe "https://auth.example.com/authorize"
+            tokenUrl shouldBe "https://auth.example.com/token"
+            refreshUrl shouldBe "https://auth.example.com/refresh"
+            scopes shouldBe mapOf("read" to "Read access")
+        }
+    }
+}

--- a/ai-mocks-gemini/api/ai-mocks-gemini.api
+++ b/ai-mocks-gemini/api/ai-mocks-gemini.api
@@ -1,6 +1,7 @@
 public final class dev/mokksy/aimocks/gemini/BlockReason : java/lang/Enum {
 	public static final field BLOCKLIST Ldev/mokksy/aimocks/gemini/BlockReason;
 	public static final field BLOCK_REASON_UNSPECIFIED Ldev/mokksy/aimocks/gemini/BlockReason;
+	public static final field Companion Ldev/mokksy/aimocks/gemini/BlockReason$Companion;
 	public static final field IMAGE_SAFETY Ldev/mokksy/aimocks/gemini/BlockReason;
 	public static final field OTHER Ldev/mokksy/aimocks/gemini/BlockReason;
 	public static final field PROHIBITED_CONTENT Ldev/mokksy/aimocks/gemini/BlockReason;
@@ -8,6 +9,10 @@ public final class dev/mokksy/aimocks/gemini/BlockReason : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Ldev/mokksy/aimocks/gemini/BlockReason;
 	public static fun values ()[Ldev/mokksy/aimocks/gemini/BlockReason;
+}
+
+public final class dev/mokksy/aimocks/gemini/BlockReason$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/mokksy/aimocks/gemini/Candidate {

--- a/ai-mocks-gemini/src/commonMain/kotlin/dev/mokksy/aimocks/gemini/Model.kt
+++ b/ai-mocks-gemini/src/commonMain/kotlin/dev/mokksy/aimocks/gemini/Model.kt
@@ -278,33 +278,40 @@ public enum class HarmProbability {
     HIGH,
 }
 
+@Serializable
 public enum class BlockReason {
     /**
      * Default value. This value is unused.
      */
+    @SerialName("BLOCK_REASON_UNSPECIFIED")
     BLOCK_REASON_UNSPECIFIED,
 
     /**
      * Prompt was blocked due to safety reasons. Inspect safetyRatings to understand which safety category blocked it.
      */
+    @SerialName("SAFETY")
     SAFETY,
 
     /**Prompt was blocked due to unknown reasons.*/
+    @SerialName("OTHER")
     OTHER,
 
     /**
      * Prompt was blocked due to the terms which are included from the terminology blocklist.
      */
+    @SerialName("BLOCKLIST")
     BLOCKLIST,
 
     /**
      * Prompt was blocked due to prohibited content.
      */
+    @SerialName("PROHIBITED_CONTENT")
     PROHIBITED_CONTENT,
 
     /**
      * Candidates blocked due to unsafe image generation content.
      */
+    @SerialName("IMAGE_SAFETY")
     IMAGE_SAFETY,
 }
 

--- a/ai-mocks-gemini/src/commonTest/kotlin/dev/mokksy/aimocks/gemini/ModelSerializationTest.kt
+++ b/ai-mocks-gemini/src/commonTest/kotlin/dev/mokksy/aimocks/gemini/ModelSerializationTest.kt
@@ -1,0 +1,599 @@
+package dev.mokksy.aimocks.gemini
+
+import dev.mokksy.test.utils.deserializeAndSerialize
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+internal class ModelSerializationTest {
+    @Test
+    fun `should serialize and deserialize SafetyCategory enum values`() {
+        // given
+        val json = """{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"BLOCK_LOW_AND_ABOVE"}"""
+
+        // when
+        val safetySetting = deserializeAndSerialize<SafetySetting>(json)
+
+        // then
+        assertSoftly(safetySetting) {
+            category shouldBe SafetyCategory.HARM_CATEGORY_HATE_SPEECH
+            threshold shouldBe HarmBlockThreshold.BLOCK_LOW_AND_ABOVE
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize all SafetyCategory values`() {
+        // when & then
+        SafetyCategory.entries.forEach { category ->
+            val safetySetting =
+                SafetySetting(
+                    category = category,
+                    threshold = HarmBlockThreshold.BLOCK_NONE,
+                )
+            val json = Json.encodeToString(SafetySetting.serializer(), safetySetting)
+            val deserialized = Json.decodeFromString(SafetySetting.serializer(), json)
+            deserialized.category shouldBe category
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize all HarmBlockThreshold values`() {
+        // when & then
+        HarmBlockThreshold.entries.forEach { threshold ->
+            val safetySetting =
+                SafetySetting(
+                    category = SafetyCategory.HARM_CATEGORY_UNSPECIFIED,
+                    threshold = threshold,
+                )
+            val json = Json.encodeToString(SafetySetting.serializer(), safetySetting)
+            val deserialized = Json.decodeFromString(SafetySetting.serializer(), json)
+            deserialized.threshold shouldBe threshold
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize SafetyRating with HarmProbability`() {
+        // given
+        val json = """{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","probability":"HIGH"}"""
+
+        // when
+        val safetyRating = deserializeAndSerialize<SafetyRating>(json)
+
+        // then
+        assertSoftly(safetyRating) {
+            category shouldBe SafetyCategory.HARM_CATEGORY_DANGEROUS_CONTENT
+            probability shouldBe HarmProbability.HIGH
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize all HarmProbability values`() {
+        // when & then
+        HarmProbability.entries.forEach { probability ->
+            val safetyRating =
+                SafetyRating(
+                    category = SafetyCategory.HARM_CATEGORY_UNSPECIFIED,
+                    probability = probability,
+                )
+            val json = Json.encodeToString(SafetyRating.serializer(), safetyRating)
+            val deserialized = Json.decodeFromString(SafetyRating.serializer(), json)
+            deserialized.probability shouldBe probability
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize UsageMetadata with all fields`() {
+        // given
+        val json =
+            """
+            {
+                "promptTokenCount": 100,
+                "cachedContentTokenCount": 50,
+                "candidatesTokenCount": 200,
+                "toolUsePromptTokenCount": 30,
+                "thoughtsTokenCount": 10,
+                "totalTokenCount": 390
+            }
+            """.trimIndent()
+
+        // when
+        val metadata = deserializeAndSerialize<UsageMetadata>(json)
+
+        // then
+        assertSoftly(metadata) {
+            promptTokenCount shouldBe 100
+            cachedContentTokenCount shouldBe 50
+            candidatesTokenCount shouldBe 200
+            toolUsePromptTokenCount shouldBe 30
+            thoughtsTokenCount shouldBe 10
+            totalTokenCount shouldBe 390
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize UsageMetadata with minimal fields`() {
+        // given
+        val json = """{"promptTokenCount": 50, "totalTokenCount": 100}"""
+
+        // when
+        val metadata = deserializeAndSerialize<UsageMetadata>(json)
+
+        // then
+        assertSoftly(metadata) {
+            promptTokenCount shouldBe 50
+            totalTokenCount shouldBe 100
+            cachedContentTokenCount shouldBe null
+            candidatesTokenCount shouldBe null
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize ModalityTokenCount`() {
+        // given
+        val json = """{"modality":"TEXT","tokenCount":42}"""
+
+        // when
+        val modalityTokenCount = deserializeAndSerialize<ModalityTokenCount>(json)
+
+        // then
+        assertSoftly(modalityTokenCount) {
+            modality shouldBe Modality.TEXT
+            tokenCount shouldBe 42
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize all Modality values`() {
+        // when & then
+        Modality.entries.forEach { modality ->
+            val modalityTokenCount =
+                ModalityTokenCount(
+                    modality = modality,
+                    tokenCount = 100,
+                )
+            val json = Json.encodeToString(ModalityTokenCount.serializer(), modalityTokenCount)
+            val deserialized = Json.decodeFromString(ModalityTokenCount.serializer(), json)
+            deserialized.modality shouldBe modality
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize UsageMetadata with token details`() {
+        // given
+        val json =
+            """
+            {
+                "promptTokenCount": 100,
+                "totalTokenCount": 200,
+                "promptTokensDetails": [
+                    {"modality": "TEXT", "tokenCount": 80},
+                    {"modality": "IMAGE", "tokenCount": 20}
+                ],
+                "candidatesTokensDetails": [
+                    {"modality": "TEXT", "tokenCount": 100}
+                ]
+            }
+            """.trimIndent()
+
+        // when
+        val metadata = deserializeAndSerialize<UsageMetadata>(json)
+
+        // then
+        assertSoftly(metadata) {
+            promptTokenCount shouldBe 100
+            totalTokenCount shouldBe 200
+            promptTokensDetails.shouldNotBeNull {
+                size shouldBe 2
+                this[0].modality shouldBe Modality.TEXT
+                this[0].tokenCount shouldBe 80
+                this[1].modality shouldBe Modality.IMAGE
+                this[1].tokenCount shouldBe 20
+            }
+            candidatesTokensDetails.shouldNotBeNull {
+                size shouldBe 1
+                this[0].modality shouldBe Modality.TEXT
+                this[0].tokenCount shouldBe 100
+            }
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize PromptFeedback with block reason`() {
+        // given
+        val json =
+            """
+            {
+                "blockReason": "SAFETY",
+                "safetyRatings": [
+                    {"category": "HARM_CATEGORY_HARASSMENT", "probability": "HIGH"}
+                ]
+            }
+            """.trimIndent()
+
+        // when
+        val feedback = deserializeAndSerialize<PromptFeedback>(json)
+
+        // then
+        assertSoftly(feedback) {
+            blockReason shouldBe BlockReason.SAFETY
+            safetyRatings.shouldNotBeNull {
+                size shouldBe 1
+                this[0].category shouldBe SafetyCategory.HARM_CATEGORY_HARASSMENT
+                this[0].probability shouldBe HarmProbability.HIGH
+            }
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize all BlockReason values`() {
+        BlockReason.entries.forEach { reason ->
+            val feedback = PromptFeedback(blockReason = reason)
+            val encoded = Json.encodeToString(PromptFeedback.serializer(), feedback)
+            val decoded = Json.decodeFromString(PromptFeedback.serializer(), encoded)
+
+            decoded.blockReason shouldBe reason
+            encoded shouldEqualJson """{"blockReason":"${reason.name}"}"""
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize GenerationConfig with all fields`() {
+        // given
+        val json =
+            """
+            {
+                "temperature": 0.9,
+                "topP": 0.8,
+                "topK": 40.0,
+                "candidateCount": 1,
+                "maxOutputTokens": 2048,
+                "stopSequences": ["STOP", "END"],
+                "responseMimeType": "application/json",
+                "seed": 12345,
+                "presencePenalty": 0.5,
+                "frequencyPenalty": 0.3,
+                "responseLogprobs": true,
+                "logprobs": 5,
+                "enableEnhancedCivicAnswers": true
+            }
+            """.trimIndent()
+
+        // when
+        val config = deserializeAndSerialize<GenerationConfig>(json)
+
+        // then
+        assertSoftly(config) {
+            temperature shouldBe 0.9
+            topP shouldBe 0.8
+            topK shouldBe 40.0f
+            candidateCount shouldBe 1
+            maxOutputTokens shouldBe 2048
+            stopSequences shouldBe listOf("STOP", "END")
+            responseMimeType shouldBe "application/json"
+            seed shouldBe 12345
+            presencePenalty shouldBe 0.5
+            frequencyPenalty shouldBe 0.3
+            responseLogprobs shouldBe true
+            logprobs shouldBe 5
+            enableEnhancedCivicAnswers shouldBe true
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize GenerationConfig with response modalities`() {
+        // given
+        val json =
+            """
+            {
+                "temperature": 0.7,
+                "responseModalities": ["TEXT", "IMAGE"]
+            }
+            """.trimIndent()
+
+        // when
+        val config = deserializeAndSerialize<GenerationConfig>(json)
+
+        // then
+        assertSoftly(config) {
+            temperature shouldBe 0.7
+            responseModalities.shouldNotBeNull {
+                size shouldBe 2
+                this[0] shouldBe Modality.TEXT
+                this[1] shouldBe Modality.IMAGE
+            }
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize all MediaResolution values`() {
+        // when & then
+        MediaResolution.entries.forEach { resolution ->
+            val config = GenerationConfig(mediaResolution = resolution)
+            val json = Json.encodeToString(GenerationConfig.serializer(), config)
+            val deserialized = Json.decodeFromString(GenerationConfig.serializer(), json)
+            deserialized.mediaResolution shouldBe resolution
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize SpeechConfig`() {
+        // given
+        val json = """{"voice": "en-US-Studio-M"}"""
+
+        // when
+        val config = deserializeAndSerialize<SpeechConfig>(json)
+
+        // then
+        config.voice shouldBe "en-US-Studio-M"
+    }
+
+    @Test
+    fun `should serialize and deserialize ThinkingConfig`() {
+        // given
+        val json = """{"enabled": true}"""
+
+        // when
+        val config = deserializeAndSerialize<ThinkingConfig>(json)
+
+        // then
+        config.enabled shouldBe true
+    }
+
+    @Test
+    fun `should serialize and deserialize GenerationConfig with speech and thinking config`() {
+        // given
+        val json =
+            """
+            {
+                "temperature": 0.8,
+                "speechConfig": {"voice": "en-US-Neural2-A"},
+                "thinkingConfig": {"enabled": true},
+                "mediaResolution": "HIGH"
+            }
+            """.trimIndent()
+
+        // when
+        val config = deserializeAndSerialize<GenerationConfig>(json)
+
+        // then
+        assertSoftly(config) {
+            temperature shouldBe 0.8
+            speechConfig.shouldNotBeNull {
+                voice shouldBe "en-US-Neural2-A"
+            }
+            thinkingConfig.shouldNotBeNull {
+                enabled shouldBe true
+            }
+            mediaResolution shouldBe MediaResolution.HIGH
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize Schema`() {
+        // given
+        val json = """{"type": "object"}"""
+
+        // when
+        val schema = deserializeAndSerialize<Schema>(json)
+
+        // then
+        schema.type shouldBe "object"
+    }
+
+    @Test
+    fun `should serialize and deserialize FunctionDeclaration`() {
+        // given
+        val json =
+            """
+            {
+                "name": "get_weather",
+                "description": "Get the weather for a location"
+            }
+            """.trimIndent()
+
+        // when
+        val functionDecl = deserializeAndSerialize<FunctionDeclaration>(json)
+
+        // then
+        assertSoftly(functionDecl) {
+            name shouldBe "get_weather"
+            description shouldBe "Get the weather for a location"
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize Tool with function declarations`() {
+        // given
+        val json =
+            """
+            {
+                "function_declarations": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get weather"
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // when
+        val tool = deserializeAndSerialize<Tool>(json)
+
+        // then
+        assertSoftly(tool) {
+            functionDeclarations.size shouldBe 1
+            functionDeclarations[0].name shouldBe "get_weather"
+            functionDeclarations[0].description shouldBe "Get weather"
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize Candidate with all fields`() {
+        // given
+        val json =
+            """
+            {
+                "content": {
+                    "parts": [{"text": "Response text"}],
+                    "role": "model"
+                },
+                "finishReason": "stop",
+                "safetyRatings": [
+                    {"category": "HARM_CATEGORY_HATE_SPEECH", "probability": "NEGLIGIBLE"}
+                ]
+            }
+            """.trimIndent()
+
+        // when
+        val candidate = deserializeAndSerialize<Candidate>(json)
+
+        // then
+        assertSoftly(candidate) {
+            content.parts.size shouldBe 1
+            content.parts[0].text shouldBe "Response text"
+            content.role shouldBe "model"
+            finishReason shouldBe "stop"
+            safetyRatings.shouldNotBeNull {
+                size shouldBe 1
+                this[0].category shouldBe SafetyCategory.HARM_CATEGORY_HATE_SPEECH
+                this[0].probability shouldBe HarmProbability.NEGLIGIBLE
+            }
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize GenerateContentResponse with all metadata`() {
+        // given
+        val json =
+            """
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": "Hello!"}]
+                        },
+                        "finishReason": "stop"
+                    }
+                ],
+                "promptFeedback": {
+                    "safetyRatings": [
+                        {"category": "HARM_CATEGORY_HARASSMENT", "probability": "LOW"}
+                    ]
+                },
+                "usageMetadata": {
+                    "promptTokenCount": 10,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 15
+                },
+                "modelVersion": "gemini-1.5-pro",
+                "responseId": "resp-123"
+            }
+            """.trimIndent()
+
+        // when
+        val response = deserializeAndSerialize<GenerateContentResponse>(json)
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            candidates[0].content.parts[0].text shouldBe "Hello!"
+            candidates[0].finishReason shouldBe "stop"
+            promptFeedback.shouldNotBeNull {
+                safetyRatings?.size shouldBe 1
+            }
+            usageMetadata.shouldNotBeNull {
+                promptTokenCount shouldBe 10
+                candidatesTokenCount shouldBe 5
+                totalTokenCount shouldBe 15
+            }
+            modelVersion shouldBe "gemini-1.5-pro"
+            responseId shouldBe "resp-123"
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize Part with text`() {
+        // given
+        val json = """{"text": "Sample text"}"""
+
+        // when
+        val part = deserializeAndSerialize<Part>(json)
+
+        // then
+        part.text shouldBe "Sample text"
+    }
+
+    @Test
+    fun `should serialize and deserialize Content with parts and role`() {
+        // given
+        val json =
+            """
+            {
+                "parts": [
+                    {"text": "First part"},
+                    {"text": "Second part"}
+                ],
+                "role": "user"
+            }
+            """.trimIndent()
+
+        // when
+        val content = deserializeAndSerialize<Content>(json)
+
+        // then
+        assertSoftly(content) {
+            parts.size shouldBe 2
+            parts[0].text shouldBe "First part"
+            parts[1].text shouldBe "Second part"
+            role shouldBe "user"
+        }
+    }
+
+    @Test
+    fun `should serialize and deserialize GenerateContentRequest`() {
+        // given
+        // language=json
+        val json =
+            """
+            {
+                "contents": [
+                    {
+                        "parts": [{"text": "Hello"}],
+                        "role": "user"
+                    }
+                ],
+                "model": "gemini-pro",
+                "systemInstruction": {
+                    "parts": [{"text": "You are helpful"}]
+                },
+                "tools": [
+                    {
+                        "function_declarations": [
+                            {"name": "search", "description": "Search the web"}
+                        ]
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        // when
+        val request = deserializeAndSerialize<GenerateContentRequest>(json)
+
+        // then
+        assertSoftly(request) {
+            contents.size shouldBe 1
+            contents[0].parts[0].text shouldBe "Hello"
+            model shouldBe "gemini-pro"
+            systemInstruction.shouldNotBeNull {
+                parts[0].text shouldBe "You are helpful"
+            }
+            tools.shouldNotBeNull {
+                size shouldBe 1
+                this[0].functionDeclarations[0].name shouldBe "search"
+            }
+        }
+    }
+}

--- a/ai-mocks-gemini/src/commonTest/kotlin/dev/mokksy/aimocks/gemini/content/GeminiHelpersTest.kt
+++ b/ai-mocks-gemini/src/commonTest/kotlin/dev/mokksy/aimocks/gemini/content/GeminiHelpersTest.kt
@@ -1,0 +1,415 @@
+package dev.mokksy.aimocks.gemini.content
+
+import dev.mokksy.aimocks.gemini.Content
+import dev.mokksy.aimocks.gemini.Part
+import dev.mokksy.aimocks.gemini.PromptFeedback
+import dev.mokksy.aimocks.gemini.UsageMetadata
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class GeminiHelpersTest {
+    @Test
+    fun `generateContentResponse should create response with default values`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "Hello, world!",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            candidates[0].content.parts.size shouldBe 1
+            candidates[0].content.parts[0].text shouldBe "Hello, world!"
+            candidates[0].finishReason shouldBe null
+            candidates[0].safetyRatings shouldBe null
+            promptFeedback shouldBe PromptFeedback(safetyRatings = null)
+            usageMetadata shouldBe
+                UsageMetadata(
+                    promptTokenCount = 0,
+                    candidatesTokenCount = 0,
+                    totalTokenCount = 0,
+                )
+            modelVersion shouldBe "gemini-pro-text-001"
+            responseId shouldBe null
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should create response with finish reason`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "Test content",
+                finishReason = "stop",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            candidates[0].content.parts[0].text shouldBe "Test content"
+            candidates[0].finishReason shouldBe "stop"
+            candidates[0].safetyRatings shouldBe null
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should create response with response ID`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "Content",
+                responseId = "response-123",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe "Content"
+            responseId shouldBe "response-123"
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should create response with custom model version`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "Content",
+                modelVersion = "gemini-1.5-pro",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe "Content"
+            modelVersion shouldBe "gemini-1.5-pro"
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should create response with all parameters`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "Complete response",
+                finishReason = "stop",
+                responseId = "resp-456",
+                modelVersion = "gemini-2.0",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            candidates[0].content.parts.size shouldBe 1
+            candidates[0].content.parts[0].text shouldBe "Complete response"
+            candidates[0].finishReason shouldBe "stop"
+            candidates[0].safetyRatings shouldBe null
+            promptFeedback shouldBe PromptFeedback(safetyRatings = null)
+            usageMetadata shouldBe
+                UsageMetadata(
+                    promptTokenCount = 0,
+                    candidatesTokenCount = 0,
+                    totalTokenCount = 0,
+                )
+            modelVersion shouldBe "gemini-2.0"
+            responseId shouldBe "resp-456"
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should handle empty content`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe ""
+            modelVersion shouldBe "gemini-pro-text-001"
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should handle multiline content`() {
+        // given
+        val multilineContent =
+            """
+            Line 1
+            Line 2
+            Line 3
+            """.trimIndent()
+
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = multilineContent,
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe multilineContent
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should handle content with special characters`() {
+        // given
+        val specialContent = "Content with 特殊文字 and émojis 🎉"
+
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = specialContent,
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe specialContent
+        }
+    }
+
+    @Test
+    fun `generateFinalContentResponse should create response with finish reason`() {
+        // when
+        val response =
+            generateFinalContentResponse(
+                finishReason = "stop",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            candidates[0].content.parts.size shouldBe 1
+            candidates[0].content.parts[0].text shouldBe ""
+            candidates[0].finishReason shouldBe "stop"
+            candidates[0].safetyRatings shouldBe null
+            promptFeedback shouldBe PromptFeedback(safetyRatings = null)
+            usageMetadata shouldBe
+                UsageMetadata(
+                    promptTokenCount = 0,
+                    candidatesTokenCount = 0,
+                    totalTokenCount = 0,
+                )
+            modelVersion shouldBe "gemini-pro-text-001"
+            responseId shouldBe null
+        }
+    }
+
+    @Test
+    fun `generateFinalContentResponse should create response with response ID`() {
+        // when
+        val response =
+            generateFinalContentResponse(
+                finishReason = "length",
+                responseId = "final-123",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe ""
+            candidates[0].finishReason shouldBe "length"
+            responseId shouldBe "final-123"
+        }
+    }
+
+    @Test
+    fun `generateFinalContentResponse should create response with custom model version`() {
+        // when
+        val response =
+            generateFinalContentResponse(
+                finishReason = "stop",
+                modelVersion = "gemini-1.5-flash",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe ""
+            candidates[0].finishReason shouldBe "stop"
+            modelVersion shouldBe "gemini-1.5-flash"
+        }
+    }
+
+    @Test
+    fun `generateFinalContentResponse should create response with all parameters`() {
+        // when
+        val response =
+            generateFinalContentResponse(
+                finishReason = "max_tokens",
+                responseId = "final-456",
+                modelVersion = "gemini-ultra",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            candidates[0].content.parts.size shouldBe 1
+            candidates[0].content.parts[0].text shouldBe ""
+            candidates[0].finishReason shouldBe "max_tokens"
+            candidates[0].safetyRatings shouldBe null
+            promptFeedback shouldBe PromptFeedback(safetyRatings = null)
+            usageMetadata shouldBe
+                UsageMetadata(
+                    promptTokenCount = 0,
+                    candidatesTokenCount = 0,
+                    totalTokenCount = 0,
+                )
+            modelVersion shouldBe "gemini-ultra"
+            responseId shouldBe "final-456"
+        }
+    }
+
+    @Test
+    fun `generateFinalContentResponse should handle different finish reasons`() {
+        // given
+        val finishReasons = listOf("stop", "length", "max_tokens", "safety", "recitation")
+
+        // when & then
+        finishReasons.forEach { reason ->
+            val response = generateFinalContentResponse(finishReason = reason)
+            assertSoftly(response) {
+                candidates[0].finishReason shouldBe reason
+                candidates[0].content.parts[0].text shouldBe ""
+            }
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should create consistent structure`() {
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = "Test",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            val candidate = candidates[0]
+            candidate.content.parts.size shouldBe 1
+            candidate.content.parts[0] shouldBe Part(text = "Test")
+            candidate.content shouldBe
+                Content(
+                    parts = listOf(Part(text = "Test")),
+                )
+        }
+    }
+
+    @Test
+    fun `generateFinalContentResponse should create consistent structure`() {
+        // when
+        val response =
+            generateFinalContentResponse(
+                finishReason = "stop",
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates.size shouldBe 1
+            val candidate = candidates[0]
+            candidate.content.parts.size shouldBe 1
+            candidate.content.parts[0] shouldBe Part(text = "")
+            candidate.content shouldBe
+                Content(
+                    parts = listOf(Part(text = "")),
+                )
+        }
+    }
+
+    @Test
+    fun `both functions should have consistent usage metadata structure`() {
+        // when
+        val response1 = generateContentResponse("Content")
+        val response2 = generateFinalContentResponse("stop")
+
+        // then
+        assertSoftly {
+            response1.usageMetadata shouldBe
+                UsageMetadata(
+                    promptTokenCount = 0,
+                    candidatesTokenCount = 0,
+                    totalTokenCount = 0,
+                )
+            response2.usageMetadata shouldBe
+                UsageMetadata(
+                    promptTokenCount = 0,
+                    candidatesTokenCount = 0,
+                    totalTokenCount = 0,
+                )
+        }
+    }
+
+    @Test
+    fun `both functions should have consistent prompt feedback structure`() {
+        // when
+        val response1 = generateContentResponse("Content")
+        val response2 = generateFinalContentResponse("stop")
+
+        // then
+        assertSoftly {
+            response1.promptFeedback shouldBe PromptFeedback(safetyRatings = null)
+            response2.promptFeedback shouldBe PromptFeedback(safetyRatings = null)
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should handle very long content`() {
+        // given
+        val longContent = "A".repeat(10000)
+
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = longContent,
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe longContent
+            candidates[0]
+                .content.parts[0]
+                .text
+                ?.length shouldBe 10000
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should handle content with JSON`() {
+        // given
+        val jsonContent = """{"name": "test", "value": 123}"""
+
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = jsonContent,
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe jsonContent
+        }
+    }
+
+    @Test
+    fun `generateContentResponse should handle content with code`() {
+        // given
+        val codeContent =
+            """
+            fun main() {
+                println("Hello, World!")
+            }
+            """.trimIndent()
+
+        // when
+        val response =
+            generateContentResponse(
+                assistantContent = codeContent,
+            )
+
+        // then
+        assertSoftly(response) {
+            candidates[0].content.parts[0].text shouldBe codeContent
+        }
+    }
+}


### PR DESCRIPTION
BlockReason enum was missing `@serializable`, causing `SerializationException`
when deserializing `PromptFeedback` with `blockReason` field.

Adopt unit tests from #577:
- SecuritySchemeBuilderTest for A2A security scheme builders
- ModelSerializationTest for Gemini model round-trip serialization
- GeminiHelpersTest for generateContentResponse helpers