### PR TITLE
fix(gemini): Added the missing trailing \r\n so each SSE event is properly terminated

### DIFF
--- a/ai-mocks-gemini/src/commonMain/kotlin/dev/mokksy/aimocks/gemini/content/GeminiStreamingContentBuildingStep.kt
+++ b/ai-mocks-gemini/src/commonMain/kotlin/dev/mokksy/aimocks/gemini/content/GeminiStreamingContentBuildingStep.kt
@@ -102,7 +102,7 @@ public class GeminiStreamingContentBuildingStep(
                 data = chunk,
             ).toString {
                 Json.encodeToString(it)
-            }
+            } + "\r\n"
         } else if (lastChunk) {
             Json.encodeToString(value = chunk)
         } else {

--- a/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/StreamingChatCompletionGenaiTest.kt
+++ b/ai-mocks-gemini/src/jvmTest/kotlin/dev/mokksy/aimocks/gemini/genai/StreamingChatCompletionGenaiTest.kt
@@ -2,8 +2,8 @@ package dev.mokksy.aimocks.gemini.genai
 
 import dev.mokksy.aimocks.gemini.gemini
 import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
-import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlin.test.Test
@@ -56,16 +56,13 @@ internal class StreamingChatCompletionGenaiTest : AbstractGenaiTest() {
                         "Just say 'Hello!'",
                         generateContentConfig(systemMessage)
                             .build(),
-                    ).joinToString(separator = "") {
-                        it.text().orEmpty()
-                    }
+                    ).toList()
             }
-
-        timedValue.value shouldBe "Ahoy there, matey! Hello!"
 
         val expectedMinDuration = initialDelay + flowDelay + delayBetweenChunks * (tokens.size - 1)
         assertSoftly(timedValue) {
-            value shouldBe "Ahoy there, matey! Hello!"
+            val chunkTexts = value.mapNotNull { chunk -> chunk.text() }
+            chunkTexts shouldContainExactly listOf("Ahoy", " there,", " matey!", " Hello!", "")
             duration shouldBeGreaterThanOrEqualTo expectedMinDuration
         }
     }


### PR DESCRIPTION
- fix(gemini): Added the missing trailing \r\n so each SSE event is properly terminated
- Update StreamingChatCompletionGenaiTest.kt to assert the chunk sequence directly, not just the concatenated final string.